### PR TITLE
Fix name mangling for C

### DIFF
--- a/src/vk_mem_alloc.h
+++ b/src/vk_mem_alloc.h
@@ -23,6 +23,10 @@
 #ifndef AMD_VULKAN_MEMORY_ALLOCATOR_H
 #define AMD_VULKAN_MEMORY_ALLOCATOR_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** \mainpage Vulkan Memory Allocator
 
 \tableofcontents
@@ -1234,6 +1238,10 @@ void vmaDestroyImage(
     VmaAllocation allocation);
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // AMD_VULKAN_MEMORY_ALLOCATOR_H
 


### PR DESCRIPTION
This patch forces the header to be compiled as C.
This behavior allows to use this library in a C program.