### PR TITLE
Fix undeclared identifier for Apple.

### DIFF
--- a/src/vk_mem_alloc.h
+++ b/src/vk_mem_alloc.h
@@ -1839,6 +1839,11 @@ remove them if not needed.
     #include <malloc.h> // for aligned_alloc()
 #endif
 
+#ifndef VMA_NULL
+   // Value used as null pointer. Define it to e.g.: nullptr, NULL, 0, (void*)0.
+   #define VMA_NULL   nullptr
+#endif
+
 #if defined(__APPLE__)
 #include <cstdlib>
 void *aligned_alloc(size_t alignment, size_t size)
@@ -1873,11 +1878,6 @@ void *aligned_alloc(size_t alignment, size_t size)
    #else
        #define VMA_HEAVY_ASSERT(expr)
    #endif
-#endif
-
-#ifndef VMA_NULL
-   // Value used as null pointer. Define it to e.g.: nullptr, NULL, 0, (void*)0.
-   #define VMA_NULL   nullptr
 #endif
 
 #ifndef VMA_ALIGN_OF


### PR DESCRIPTION
Hi,
I got a compile error on macOS.
```
vk_mem_alloc.h:
1855:12: error:
      use of undeclared identifier 'VMA_NULL'
    return VMA_NULL;
```
And, I fixed the issue.
Thank you.

OS: Mac OS X 10.13.3
Compiler: clang-900.0.39.2