### PR TITLE
Unbreak on BSDs

### DIFF
--- a/src/vk_mem_alloc.h
+++ b/src/vk_mem_alloc.h
@@ -2229,10 +2229,6 @@ remove them if not needed.
 #include <mutex> // for std::mutex
 #include <atomic> // for std::atomic
 
-#if !defined(_WIN32) && !defined(__APPLE__)
-    #include <malloc.h> // for aligned_alloc()
-#endif
-
 #ifndef VMA_NULL
    // Value used as null pointer. Define it to e.g.: nullptr, NULL, 0, (void*)0.
    #define VMA_NULL   nullptr


### PR DESCRIPTION
`aligned_alloc` is defined in `<stdlib.h>`even on Linux. [FreeBSD](https://github.com/freebsd/freebsd/commit/2ffad81b1757554bf9413d11af0e92c93a94575b), [DragonFly](https://github.com/DragonFlyBSD/DragonFlyBSD/commit/02b66c54cac986a0bf93435b8d5ae1b17521515b), [OpenBSD](https://github.com/openbsd/src/commit/d88f57029e5acaaaf028633c7fa15c5d7325c5cc) don't support `<malloc.h>` while GNU libc uses `<malloc.h>` for non-standard extensions: `malloc_usable_size`, `mallinfo`, `memalign`, `pvalloc`, etc.
