### PR TITLE
Fixes warning: field 'm_Blocks' will be initialized after field 'm_HasEmptyBlock' [-Wreorder]

### DIFF
--- a/src/vk_mem_alloc.h
+++ b/src/vk_mem_alloc.h
@@ -9380,8 +9380,8 @@ VmaBlockVector::VmaBlockVector(
     m_IsCustomPool(isCustomPool),
     m_ExplicitBlockSize(explicitBlockSize),
     m_LinearAlgorithm(linearAlgorithm),
-    m_Blocks(VmaStlAllocator<VmaDeviceMemoryBlock*>(hAllocator->GetAllocationCallbacks())),
     m_HasEmptyBlock(false),
+    m_Blocks(VmaStlAllocator<VmaDeviceMemoryBlock*>(hAllocator->GetAllocationCallbacks())),
     m_pDefragmentator(VMA_NULL),
     m_NextBlockId(0)
 {


### PR DESCRIPTION
See title.

Thanks, 
btw: **Great work.**