### PR TITLE
Suppres warnings when NOMINMAX already defined

### DIFF
--- a/src/vk_mem_alloc.h
+++ b/src/vk_mem_alloc.h
@@ -1369,7 +1369,9 @@ available through VmaAllocatorCreateInfo::pRecordSettings.
     #endif
 #endif
 
+#ifndef NOMINMAX
 #define NOMINMAX // For Windows.h
+#endif
 
 #include <vulkan/vulkan.h>
 


### PR DESCRIPTION
My project already has a CMake level definition for NOMINMAX on Win32 platforms, so this raw redefinition triggers 

`warning C4005: 'NOMINMAX': macro redefinition (compiling source file ...)`

This small change should prevent the warnings in situations like this.
