### PR TITLE
Avoid redefinition warnings of NOMINMAX by checking if it's already been defined.

### DIFF
--- a/src/vk_mem_alloc.h
+++ b/src/vk_mem_alloc.h
@@ -1369,7 +1369,9 @@ available through VmaAllocatorCreateInfo::pRecordSettings.
     #endif
 #endif
 
+#ifndef NOMINMAX
 #define NOMINMAX // For Windows.h
+#endif
 
 #include <vulkan/vulkan.h>
 


### PR DESCRIPTION
I tend to define this one globally. To avoid redefinition warnings, it's best to check if it's already been defined.