### PR TITLE
Fixed an issue with STL_CONTAINER compilation.

### DIFF
--- a/src/vk_mem_alloc.h
+++ b/src/vk_mem_alloc.h
@@ -10527,7 +10527,7 @@ void VmaBlockMetadata_Linear::CleanupAfterFree()
             suballocations2nd[0].hAllocation == VK_NULL_HANDLE)
         {
             --m_2ndNullItemsCount;
-            suballocations2nd.remove(0);
+            VmaVectorRemove(suballocations2nd, 0);
         }
 
         if(ShouldCompact1st())


### PR DESCRIPTION
Fixed an issue where defining the VMA_USE_STL_CONTAINERS
macro would prevent VMA from compiling. This was caused by calling a
VMA-container-specific function instead of the macro meant for
abstracting away the differences.

This fixes #60 