### PR TITLE
Use VK_NULL_HANDLE for VkBuffer init (not VMA_NULL)

### DIFF
--- a/src/vk_mem_alloc.h
+++ b/src/vk_mem_alloc.h
@@ -15592,7 +15592,7 @@ uint32_t VmaAllocator_T::CalculateGpuDefragmentationMemoryTypeBits() const
     uint32_t memoryTypeBits = 0;
 
     // Create buffer.
-    VkBuffer buf = VMA_NULL;
+    VkBuffer buf = VK_NULL_HANDLE;
     VkResult res = (*GetVulkanFunctions().vkCreateBuffer)(
         m_hDevice, &dummyBufCreateInfo, GetAllocationCallbacks(), &buf);
     if(res == VK_SUCCESS)


### PR DESCRIPTION
I couldn't build for Android armv7a without this change.