### PR TITLE
Guard VmaWriteMagicValue / VmaValidateMagicValue on VMA_DEBUG_MARGIN > 0

### DIFF
--- a/src/vk_mem_alloc.h
+++ b/src/vk_mem_alloc.h
@@ -3725,16 +3725,21 @@ static inline bool VmaIsBufferImageGranularityConflict(
 
 static void VmaWriteMagicValue(void* pData, VkDeviceSize offset)
 {
+#if VMA_DEBUG_MARGIN > 0
     uint32_t* pDst = (uint32_t*)((char*)pData + offset);
     const size_t numberCount = VMA_DEBUG_MARGIN / sizeof(uint32_t);
     for(size_t i = 0; i < numberCount; ++i, ++pDst)
     {
         *pDst = VMA_CORRUPTION_DETECTION_MAGIC_VALUE;
     }
+#else
+	// no-op
+#endif
 }
 
 static bool VmaValidateMagicValue(const void* pData, VkDeviceSize offset)
 {
+#if VMA_DEBUG_MARGIN > 0
     const uint32_t* pSrc = (const uint32_t*)((const char*)pData + offset);
     const size_t numberCount = VMA_DEBUG_MARGIN / sizeof(uint32_t);
     for(size_t i = 0; i < numberCount; ++i, ++pSrc)
@@ -3744,6 +3749,7 @@ static bool VmaValidateMagicValue(const void* pData, VkDeviceSize offset)
             return false;
         }
     }
+#endif
     return true;
 }
 


### PR DESCRIPTION
Fixes #68, if `VMA_DEBUG_MARGIN` is <= ` 0` (the default)

This has the additional effect of preventing `-Wcast-align` warnings (again, as long as `VMA_DEBUG_MARGIN` is <= `0`):

```
vk_mem_alloc.h:3729:22: error: cast from 'char *' to 'uint32_t *' (aka 'unsigned int *') increases required alignment from 1 to 4 [-Werror,-Wcast-align]
    uint32_t* pDst = (uint32_t*)((char*)pData + offset);
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
vk_mem_alloc.h:3743:28: error: cast from 'const char *' to 'const uint32_t *' (aka 'const unsigned int *') increases required alignment from 1 to 4 [-Werror,-Wcast-align]
    const uint32_t* pSrc = (const uint32_t*)((const char*)pData + offset);
                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```