### PR TITLE
Ensure m_VulkanFunctions pointers are initialized to null if not assigned

### DIFF
--- a/src/vk_mem_alloc.h
+++ b/src/vk_mem_alloc.h
@@ -14313,6 +14313,11 @@ void VmaAllocator_T::ImportVulkanFunctions(const VmaVulkanFunctions* pVulkanFunc
         m_VulkanFunctions.vkGetImageMemoryRequirements2KHR =
             (PFN_vkGetImageMemoryRequirements2KHR)vkGetDeviceProcAddr(m_hDevice, "vkGetImageMemoryRequirements2KHR");
     }
+    else
+    {
+        m_VulkanFunctions.vkGetBufferMemoryRequirements2KHR = nullptr;
+        m_VulkanFunctions.vkGetImageMemoryRequirements2KHR = nullptr;
+    }
 #endif // #if VMA_DEDICATED_ALLOCATION
 #if VMA_BIND_MEMORY2
     if(m_UseKhrBindMemory2)
@@ -14322,7 +14327,14 @@ void VmaAllocator_T::ImportVulkanFunctions(const VmaVulkanFunctions* pVulkanFunc
         m_VulkanFunctions.vkBindImageMemory2KHR =
             (PFN_vkBindImageMemory2KHR)vkGetDeviceProcAddr(m_hDevice, "vkBindImageMemory2KHR");
     }
+    else
+    {
+        m_VulkanFunctions.vkBindBufferMemory2KHR = nullptr;
+        m_VulkanFunctions.vkBindImageMemory2KHR = nullptr;
+    }
 #endif // #if VMA_BIND_MEMORY2
+#else
+    m_VulkanFunctions = VmaVulkanFunctions{};
 #endif // #if VMA_STATIC_VULKAN_FUNCTIONS == 1
 
 #define VMA_COPY_IF_NOT_NULL(funcName) \


### PR DESCRIPTION
In certain scenarios `m_VulkanFunctions` will be initialized with non-null garbage. (My specific case: MSVC debug build, `VMA_STATIC_VULKAN_FUNCTIONS=0`, and no `pVulkanFunctions` given.)
The garbage means that the `VMA_ASSERT`s for the functions don't trigger, rather you'll get a crash when the garbage pointer is called.
(Or worse, if the garbage happens to be callable, some possibly rather puzzling-at-first misbehaviour.)

Explicitly initializing the structure to 0 ensures that the asserts trigger as intended. (Or in release builds, prevents callable garbage pointers.)