### PR TITLE
Use fallback aligned_alloc for pre-C++17 glibc++

### DIFF
--- a/src/vk_mem_alloc.h
+++ b/src/vk_mem_alloc.h
@@ -3302,7 +3302,7 @@ void *aligned_alloc(size_t alignment, size_t size)
 
     return memalign(alignment, size);
 }
-#elif defined(__APPLE__) || defined(__ANDROID__)
+#elif defined(__APPLE__) || defined(__ANDROID__) || (defined(__GLIBCXX__) && !defined(_GLIBCXX_HAVE_ALIGNED_ALLOC))
 #include <cstdlib>
 void *aligned_alloc(size_t alignment, size_t size)
 {


### PR DESCRIPTION
Function aligned_alloc was [added to C++17](https://en.cppreference.com/w/cpp/memory/c/aligned_alloc); using it in older build environment causes compilation error (e.g. in GCC 5.4.0 or Clang 3.4.2).

This change in ifdef fixes this problem for older build environments.

Build log *without* this change:

````
+ g++ --version
g++ (SteamRT 5.4.0-7.really.6+steamrt1.2+srt2) 5.4.1 20160803
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

+ g++ -std=c++14 test.cpp -lvulkan
In file included from test.cpp:2:0:
source/src/vk_mem_alloc.h: In function 'void* VmaMalloc(const VkAllocationCallbacks*, size_t, size_t)':
source/src/vk_mem_alloc.h:3354:96: error: 'aligned_alloc' was not declared in this scope
        #define VMA_SYSTEM_ALIGNED_MALLOC(size, alignment)   (aligned_alloc((alignment), (size) ))
                                                                                                ^
source/src/vk_mem_alloc.h:3976:16: note: in expansion of macro 'VMA_SYSTEM_ALIGNED_MALLOC'
         return VMA_SYSTEM_ALIGNED_MALLOC(size, alignment);
                ^
+ clang++ --version
SteamRT clang version 3.4.2- (branches/release_34) (based on LLVM 3.4.2)
Target: x86_64-pc-linux-gnu
Thread model: posix
+ clang++ -std=c++11 test.cpp -lvulkan
In file included from test.cpp:2:
./source/src/vk_mem_alloc.h:3976:16: error: use of undeclared identifier 'aligned_alloc'
        return VMA_SYSTEM_ALIGNED_MALLOC(size, alignment);
               ^
./source/src/vk_mem_alloc.h:3354:62: note: expanded from macro 'VMA_SYSTEM_ALIGNED_MALLOC'
       #define VMA_SYSTEM_ALIGNED_MALLOC(size, alignment)   (aligned_alloc((alignment), (size) ))
                                                             ^
1 error generated.
````

I encountered this problem when building GZDoom inside Steam Runtime build environment (dreamer/luxtorpeda#35, coelckers/gzdoom#904), but I assume it will be a problem when packaging vkDOOM3 and vkQuake2 in future.
