### PR TITLE
Export functions for building as a Windows standalone library

### DIFF
--- a/src/VmaUsage.h
+++ b/src/VmaUsage.h
@@ -33,8 +33,8 @@
 // Uncomment to test including `vulkan.h` on your own before including VMA.
 //#include <vulkan/vulkan.h>
 
-// Uncomment to export functions when building VMA as a shared library.
-//#define VMA_DLL_EXPORT
+// Uncomment when building VMA as a standalone library.
+//#define VMA_STANDALONE
 
 /*
 In every place where you want to use Vulkan Memory Allocator, define appropriate

--- a/src/VmaUsage.h
+++ b/src/VmaUsage.h
@@ -33,6 +33,9 @@
 // Uncomment to test including `vulkan.h` on your own before including VMA.
 //#include <vulkan/vulkan.h>
 
+// Uncomment to export functions when building VMA as a shared library.
+//#define VMA_DLL_EXPORT
+
 /*
 In every place where you want to use Vulkan Memory Allocator, define appropriate
 macros if you want to configure the library and then include its header to

--- a/src/vk_mem_alloc.h
+++ b/src/vk_mem_alloc.h
@@ -1718,7 +1718,7 @@ available through VmaAllocatorCreateInfo::pRecordSettings.
     #endif
 #endif
 
-#if !defined(VMA_DLL_EXPORT)
+#if !defined(VMA_STANDALONE)
 	#define DECLSPEC
 	#define VMACALL
 #else

--- a/src/vk_mem_alloc.h
+++ b/src/vk_mem_alloc.h
@@ -1718,6 +1718,14 @@ available through VmaAllocatorCreateInfo::pRecordSettings.
     #endif
 #endif
 
+#if !defined(VMA_DLL_EXPORT)
+	#define DECLSPEC
+	#define VMACALL
+#else
+	#define DECLSPEC __declspec(dllexport)
+	#define VMACALL __cdecl
+#endif
+
 /** \struct VmaAllocator
 \brief Represents main object of this library initialized.
 
@@ -1943,19 +1951,19 @@ typedef struct VmaAllocatorCreateInfo
 } VmaAllocatorCreateInfo;
 
 /// Creates Allocator object.
-VkResult vmaCreateAllocator(
+DECLSPEC VkResult VMACALL vmaCreateAllocator(
     const VmaAllocatorCreateInfo* pCreateInfo,
     VmaAllocator* pAllocator);
 
 /// Destroys allocator object.
-void vmaDestroyAllocator(
+DECLSPEC void VMACALL vmaDestroyAllocator(
     VmaAllocator allocator);
 
 /**
 PhysicalDeviceProperties are fetched from physicalDevice by the allocator.
 You can access it here, without fetching it again on your own.
 */
-void vmaGetPhysicalDeviceProperties(
+DECLSPEC void VMACALL vmaGetPhysicalDeviceProperties(
     VmaAllocator allocator,
     const VkPhysicalDeviceProperties** ppPhysicalDeviceProperties);
 
@@ -1963,7 +1971,7 @@ void vmaGetPhysicalDeviceProperties(
 PhysicalDeviceMemoryProperties are fetched from physicalDevice by the allocator.
 You can access it here, without fetching it again on your own.
 */
-void vmaGetMemoryProperties(
+DECLSPEC void VMACALL vmaGetMemoryProperties(
     VmaAllocator allocator,
     const VkPhysicalDeviceMemoryProperties** ppPhysicalDeviceMemoryProperties);
 
@@ -1973,7 +1981,7 @@ void vmaGetMemoryProperties(
 This is just a convenience function. Same information can be obtained using
 vmaGetMemoryProperties().
 */
-void vmaGetMemoryTypeProperties(
+DECLSPEC void VMACALL vmaGetMemoryTypeProperties(
     VmaAllocator allocator,
     uint32_t memoryTypeIndex,
     VkMemoryPropertyFlags* pFlags);
@@ -1986,7 +1994,7 @@ This function must be used if you make allocations with
 when a new frame begins. Allocations queried using vmaGetAllocationInfo() cannot
 become lost in the current frame.
 */
-void vmaSetCurrentFrameIndex(
+DECLSPEC void VMACALL vmaSetCurrentFrameIndex(
     VmaAllocator allocator,
     uint32_t frameIndex);
 
@@ -2017,7 +2025,7 @@ typedef struct VmaStats
 } VmaStats;
 
 /// Retrieves statistics from current state of the Allocator.
-void vmaCalculateStats(
+DECLSPEC void VMACALL vmaCalculateStats(
     VmaAllocator allocator,
     VmaStats* pStats);
 
@@ -2030,12 +2038,12 @@ void vmaCalculateStats(
 /// Builds and returns statistics as string in JSON format.
 /** @param[out] ppStatsString Must be freed using vmaFreeStatsString() function.
 */
-void vmaBuildStatsString(
+DECLSPEC void VMACALL vmaBuildStatsString(
     VmaAllocator allocator,
     char** ppStatsString,
     VkBool32 detailedMap);
 
-void vmaFreeStatsString(
+DECLSPEC void VMACALL vmaFreeStatsString(
     VmaAllocator allocator,
     char* pStatsString);
 
@@ -2270,7 +2278,7 @@ device doesn't support any memory type with requested features for the specific
 type of resource you want to use it for. Please check parameters of your
 resource, like image layout (OPTIMAL versus LINEAR) or mip level count.
 */
-VkResult vmaFindMemoryTypeIndex(
+DECLSPEC VkResult VMACALL vmaFindMemoryTypeIndex(
     VmaAllocator allocator,
     uint32_t memoryTypeBits,
     const VmaAllocationCreateInfo* pAllocationCreateInfo,
@@ -2288,7 +2296,7 @@ It is just a convenience function, equivalent to calling:
 - `vmaFindMemoryTypeIndex`
 - `vkDestroyBuffer`
 */
-VkResult vmaFindMemoryTypeIndexForBufferInfo(
+DECLSPEC VkResult VMACALL vmaFindMemoryTypeIndexForBufferInfo(
     VmaAllocator allocator,
     const VkBufferCreateInfo* pBufferCreateInfo,
     const VmaAllocationCreateInfo* pAllocationCreateInfo,
@@ -2306,7 +2314,7 @@ It is just a convenience function, equivalent to calling:
 - `vmaFindMemoryTypeIndex`
 - `vkDestroyImage`
 */
-VkResult vmaFindMemoryTypeIndexForImageInfo(
+DECLSPEC VkResult VMACALL vmaFindMemoryTypeIndexForImageInfo(
     VmaAllocator allocator,
     const VkImageCreateInfo* pImageCreateInfo,
     const VmaAllocationCreateInfo* pAllocationCreateInfo,
@@ -2451,14 +2459,14 @@ typedef struct VmaPoolStats {
 @param pCreateInfo Parameters of pool to create.
 @param[out] pPool Handle to created pool.
 */
-VkResult vmaCreatePool(
+DECLSPEC VkResult VMACALL vmaCreatePool(
 	VmaAllocator allocator,
 	const VmaPoolCreateInfo* pCreateInfo,
 	VmaPool* pPool);
 
 /** \brief Destroys #VmaPool object and frees Vulkan device memory.
 */
-void vmaDestroyPool(
+DECLSPEC void VMACALL vmaDestroyPool(
     VmaAllocator allocator,
     VmaPool pool);
 
@@ -2468,7 +2476,7 @@ void vmaDestroyPool(
 @param pool Pool object.
 @param[out] pPoolStats Statistics of specified pool.
 */
-void vmaGetPoolStats(
+DECLSPEC void VMACALL vmaGetPoolStats(
     VmaAllocator allocator,
     VmaPool pool,
     VmaPoolStats* pPoolStats);
@@ -2479,7 +2487,7 @@ void vmaGetPoolStats(
 @param pool Pool.
 @param[out] pLostAllocationCount Number of allocations marked as lost. Optional - pass null if you don't need this information.
 */
-void vmaMakePoolAllocationsLost(
+DECLSPEC void VMACALL vmaMakePoolAllocationsLost(
     VmaAllocator allocator,
     VmaPool pool,
     size_t* pLostAllocationCount);
@@ -2498,7 +2506,7 @@ Possible return values:
   `VMA_ASSERT` is also fired in that case.
 - Other value: Error returned by Vulkan, e.g. memory mapping failure.
 */
-VkResult vmaCheckPoolCorruption(VmaAllocator allocator, VmaPool pool);
+DECLSPEC VkResult VMACALL vmaCheckPoolCorruption(VmaAllocator allocator, VmaPool pool);
 
 /** \struct VmaAllocation
 \brief Represents single memory allocation.
@@ -2579,7 +2587,7 @@ You should free the memory using vmaFreeMemory() or vmaFreeMemoryPages().
 It is recommended to use vmaAllocateMemoryForBuffer(), vmaAllocateMemoryForImage(),
 vmaCreateBuffer(), vmaCreateImage() instead whenever possible.
 */
-VkResult vmaAllocateMemory(
+DECLSPEC VkResult VMACALL vmaAllocateMemory(
     VmaAllocator allocator,
     const VkMemoryRequirements* pVkMemoryRequirements,
     const VmaAllocationCreateInfo* pCreateInfo,
@@ -2605,7 +2613,7 @@ All allocations are made using same parameters. All of them are created out of t
 If any allocation fails, all allocations already made within this function call are also freed, so that when
 returned result is not `VK_SUCCESS`, `pAllocation` array is always entirely filled with `VK_NULL_HANDLE`.
 */
-VkResult vmaAllocateMemoryPages(
+DECLSPEC VkResult VMACALL vmaAllocateMemoryPages(
     VmaAllocator allocator,
     const VkMemoryRequirements* pVkMemoryRequirements,
     const VmaAllocationCreateInfo* pCreateInfo,
@@ -2619,7 +2627,7 @@ VkResult vmaAllocateMemoryPages(
 
 You should free the memory using vmaFreeMemory().
 */
-VkResult vmaAllocateMemoryForBuffer(
+DECLSPEC VkResult VMACALL vmaAllocateMemoryForBuffer(
     VmaAllocator allocator,
     VkBuffer buffer,
     const VmaAllocationCreateInfo* pCreateInfo,
@@ -2627,7 +2635,7 @@ VkResult vmaAllocateMemoryForBuffer(
     VmaAllocationInfo* pAllocationInfo);
 
 /// Function similar to vmaAllocateMemoryForBuffer().
-VkResult vmaAllocateMemoryForImage(
+DECLSPEC VkResult VMACALL vmaAllocateMemoryForImage(
     VmaAllocator allocator,
     VkImage image,
     const VmaAllocationCreateInfo* pCreateInfo,
@@ -2638,7 +2646,7 @@ VkResult vmaAllocateMemoryForImage(
 
 Passing `VK_NULL_HANDLE` as `allocation` is valid. Such function call is just skipped.
 */
-void vmaFreeMemory(
+DECLSPEC void VMACALL vmaFreeMemory(
     VmaAllocator allocator,
     VmaAllocation allocation);
 
@@ -2652,7 +2660,7 @@ It may be internally optimized to be more efficient than calling vmaFreeMemory()
 Allocations in `pAllocations` array can come from any memory pools and types.
 Passing `VK_NULL_HANDLE` as elements of `pAllocations` array is valid. Such entries are just skipped.
 */
-void vmaFreeMemoryPages(
+DECLSPEC void VMACALL vmaFreeMemoryPages(
     VmaAllocator allocator,
     size_t allocationCount,
     VmaAllocation* pAllocations);
@@ -2663,7 +2671,7 @@ In version 2.2.0 it used to try to change allocation's size without moving or re
 In current version it returns `VK_SUCCESS` only if `newSize` equals current allocation's size.
 Otherwise returns `VK_ERROR_OUT_OF_POOL_MEMORY`, indicating that allocation's size could not be changed.
 */
-VkResult vmaResizeAllocation(
+DECLSPEC VkResult VMACALL vmaResizeAllocation(
     VmaAllocator allocator,
     VmaAllocation allocation,
     VkDeviceSize newSize);
@@ -2684,7 +2692,7 @@ you can avoid calling it too often.
   (e.g. due to defragmentation or allocation becoming lost).
 - If you just want to check if allocation is not lost, vmaTouchAllocation() will work faster.
 */
-void vmaGetAllocationInfo(
+DECLSPEC void VMACALL vmaGetAllocationInfo(
     VmaAllocator allocator,
     VmaAllocation allocation,
     VmaAllocationInfo* pAllocationInfo);
@@ -2703,7 +2711,7 @@ Lost allocation and the buffer/image still need to be destroyed.
 If the allocation has been created without #VMA_ALLOCATION_CREATE_CAN_BECOME_LOST_BIT flag,
 this function always returns `VK_TRUE`.
 */
-VkBool32 vmaTouchAllocation(
+DECLSPEC VkBool32 VMACALL vmaTouchAllocation(
     VmaAllocator allocator,
     VmaAllocation allocation);
 
@@ -2720,7 +2728,7 @@ If the flag was not used, the value of pointer `pUserData` is just copied to
 allocation's `pUserData`. It is opaque, so you can use it however you want - e.g.
 as a pointer, ordinal number or some handle to you own data.
 */
-void vmaSetAllocationUserData(
+DECLSPEC void VMACALL vmaSetAllocationUserData(
     VmaAllocator allocator,
     VmaAllocation allocation,
     void* pUserData);
@@ -2735,7 +2743,7 @@ Returned allocation is not tied to any specific memory pool or memory type and
 not bound to any image or buffer. It has size = 0. It cannot be turned into
 a real, non-empty allocation.
 */
-void vmaCreateLostAllocation(
+DECLSPEC void VMACALL vmaCreateLostAllocation(
     VmaAllocator allocator,
     VmaAllocation* pAllocation);
 
@@ -2773,7 +2781,7 @@ This function always fails when called for allocation that was created with
 #VMA_ALLOCATION_CREATE_CAN_BECOME_LOST_BIT flag. Such allocations cannot be
 mapped.
 */
-VkResult vmaMapMemory(
+DECLSPEC VkResult VMACALL vmaMapMemory(
     VmaAllocator allocator,
     VmaAllocation allocation,
     void** ppData);
@@ -2782,7 +2790,7 @@ VkResult vmaMapMemory(
 
 For details, see description of vmaMapMemory().
 */
-void vmaUnmapMemory(
+DECLSPEC void VMACALL vmaUnmapMemory(
     VmaAllocator allocator,
     VmaAllocation allocation);
 
@@ -2802,7 +2810,7 @@ Warning! `offset` and `size` are relative to the contents of given `allocation`.
 If you mean whole allocation, you can pass 0 and `VK_WHOLE_SIZE`, respectively.
 Do not pass allocation's offset as `offset`!!!
 */
-void vmaFlushAllocation(VmaAllocator allocator, VmaAllocation allocation, VkDeviceSize offset, VkDeviceSize size);
+DECLSPEC void VMACALL vmaFlushAllocation(VmaAllocator allocator, VmaAllocation allocation, VkDeviceSize offset, VkDeviceSize size);
 
 /** \brief Invalidates memory of given allocation.
 
@@ -2820,7 +2828,7 @@ Warning! `offset` and `size` are relative to the contents of given `allocation`.
 If you mean whole allocation, you can pass 0 and `VK_WHOLE_SIZE`, respectively.
 Do not pass allocation's offset as `offset`!!!
 */
-void vmaInvalidateAllocation(VmaAllocator allocator, VmaAllocation allocation, VkDeviceSize offset, VkDeviceSize size);
+DECLSPEC void VMACALL vmaInvalidateAllocation(VmaAllocator allocator, VmaAllocation allocation, VkDeviceSize offset, VkDeviceSize size);
 
 /** \brief Checks magic number in margins around all allocations in given memory types (in both default and custom pools) in search for corruptions.
 
@@ -2838,7 +2846,7 @@ Possible return values:
   `VMA_ASSERT` is also fired in that case.
 - Other value: Error returned by Vulkan, e.g. memory mapping failure.
 */
-VkResult vmaCheckCorruption(VmaAllocator allocator, uint32_t memoryTypeBits);
+DECLSPEC VkResult VMACALL vmaCheckCorruption(VmaAllocator allocator, uint32_t memoryTypeBits);
 
 /** \struct VmaDefragmentationContext
 \brief Represents Opaque object that represents started defragmentation process.
@@ -2988,7 +2996,7 @@ Warning! Between the call to vmaDefragmentationBegin() and vmaDefragmentationEnd
 For more information and important limitations regarding defragmentation, see documentation chapter:
 [Defragmentation](@ref defragmentation).
 */
-VkResult vmaDefragmentationBegin(
+DECLSPEC VkResult VMACALL vmaDefragmentationBegin(
     VmaAllocator allocator,
     const VmaDefragmentationInfo2* pInfo,
     VmaDefragmentationStats* pStats,
@@ -2999,7 +3007,7 @@ VkResult vmaDefragmentationBegin(
 Use this function to finish defragmentation started by vmaDefragmentationBegin().
 It is safe to pass `context == null`. The function then does nothing.
 */
-VkResult vmaDefragmentationEnd(
+DECLSPEC VkResult VMACALL vmaDefragmentationEnd(
     VmaAllocator allocator,
     VmaDefragmentationContext context);
 
@@ -3043,7 +3051,7 @@ you should measure that on your platform.
 
 For more information, see [Defragmentation](@ref defragmentation) chapter.
 */
-VkResult vmaDefragment(
+DECLSPEC VkResult VMACALL vmaDefragment(
     VmaAllocator allocator,
     VmaAllocation* pAllocations,
     size_t allocationCount,
@@ -3063,7 +3071,7 @@ allocations, calls to `vkBind*Memory()` or `vkMapMemory()` won't happen from mul
 
 It is recommended to use function vmaCreateBuffer() instead of this one.
 */
-VkResult vmaBindBufferMemory(
+DECLSPEC VkResult VMACALL vmaBindBufferMemory(
     VmaAllocator allocator,
     VmaAllocation allocation,
     VkBuffer buffer);
@@ -3078,7 +3086,7 @@ This function is similar to vmaBindBufferMemory(), but it provides additional pa
 If `pNext` is not null, #VmaAllocator object must have been created with #VMA_ALLOCATOR_CREATE_KHR_BIND_MEMORY2_BIT flag.
 Otherwise the call fails.
 */
-VkResult vmaBindBufferMemory2(
+DECLSPEC VkResult VMACALL vmaBindBufferMemory2(
     VmaAllocator allocator,
     VmaAllocation allocation,
     VkDeviceSize allocationLocalOffset,
@@ -3097,7 +3105,7 @@ allocations, calls to `vkBind*Memory()` or `vkMapMemory()` won't happen from mul
 
 It is recommended to use function vmaCreateImage() instead of this one.
 */
-VkResult vmaBindImageMemory(
+DECLSPEC VkResult VMACALL vmaBindImageMemory(
     VmaAllocator allocator,
     VmaAllocation allocation,
     VkImage image);
@@ -3112,7 +3120,7 @@ This function is similar to vmaBindImageMemory(), but it provides additional par
 If `pNext` is not null, #VmaAllocator object must have been created with #VMA_ALLOCATOR_CREATE_KHR_BIND_MEMORY2_BIT flag.
 Otherwise the call fails.
 */
-VkResult vmaBindImageMemory2(
+DECLSPEC VkResult VMACALL vmaBindImageMemory2(
     VmaAllocator allocator,
     VmaAllocation allocation,
     VkDeviceSize allocationLocalOffset,
@@ -3145,7 +3153,7 @@ and VMA_ALLOCATION_CREATE_NEVER_ALLOCATE_BIT is not used), it creates dedicated
 allocation for this buffer, just like when using
 VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT.
 */
-VkResult vmaCreateBuffer(
+DECLSPEC VkResult VMACALL vmaCreateBuffer(
     VmaAllocator allocator,
     const VkBufferCreateInfo* pBufferCreateInfo,
     const VmaAllocationCreateInfo* pAllocationCreateInfo,
@@ -3164,13 +3172,13 @@ vmaFreeMemory(allocator, allocation);
 
 It it safe to pass null as buffer and/or allocation.
 */
-void vmaDestroyBuffer(
+DECLSPEC void VMACALL vmaDestroyBuffer(
     VmaAllocator allocator,
     VkBuffer buffer,
     VmaAllocation allocation);
 
 /// Function similar to vmaCreateBuffer().
-VkResult vmaCreateImage(
+DECLSPEC VkResult VMACALL vmaCreateImage(
     VmaAllocator allocator,
     const VkImageCreateInfo* pImageCreateInfo,
     const VmaAllocationCreateInfo* pAllocationCreateInfo,
@@ -3189,7 +3197,7 @@ vmaFreeMemory(allocator, allocation);
 
 It it safe to pass null as image and/or allocation.
 */
-void vmaDestroyImage(
+DECLSPEC void VMACALL vmaDestroyImage(
     VmaAllocator allocator,
     VkImage image,
     VmaAllocation allocation);
@@ -15757,7 +15765,7 @@ void VmaAllocator_T::PrintDetailedMap(VmaJsonWriter& json)
 ////////////////////////////////////////////////////////////////////////////////
 // Public interface
 
-VkResult vmaCreateAllocator(
+DECLSPEC VkResult VMACALL vmaCreateAllocator(
     const VmaAllocatorCreateInfo* pCreateInfo,
     VmaAllocator* pAllocator)
 {
@@ -15767,7 +15775,7 @@ VkResult vmaCreateAllocator(
     return (*pAllocator)->Init(pCreateInfo);
 }
 
-void vmaDestroyAllocator(
+DECLSPEC void VMACALL vmaDestroyAllocator(
     VmaAllocator allocator)
 {
     if(allocator != VK_NULL_HANDLE)
@@ -15778,7 +15786,7 @@ void vmaDestroyAllocator(
     }
 }
 
-void vmaGetPhysicalDeviceProperties(
+DECLSPEC void VMACALL vmaGetPhysicalDeviceProperties(
     VmaAllocator allocator,
     const VkPhysicalDeviceProperties **ppPhysicalDeviceProperties)
 {
@@ -15786,7 +15794,7 @@ void vmaGetPhysicalDeviceProperties(
     *ppPhysicalDeviceProperties = &allocator->m_PhysicalDeviceProperties;
 }
 
-void vmaGetMemoryProperties(
+DECLSPEC void VMACALL vmaGetMemoryProperties(
     VmaAllocator allocator,
     const VkPhysicalDeviceMemoryProperties** ppPhysicalDeviceMemoryProperties)
 {
@@ -15794,7 +15802,7 @@ void vmaGetMemoryProperties(
     *ppPhysicalDeviceMemoryProperties = &allocator->m_MemProps;
 }
 
-void vmaGetMemoryTypeProperties(
+DECLSPEC void VMACALL vmaGetMemoryTypeProperties(
     VmaAllocator allocator,
     uint32_t memoryTypeIndex,
     VkMemoryPropertyFlags* pFlags)
@@ -15804,7 +15812,7 @@ void vmaGetMemoryTypeProperties(
     *pFlags = allocator->m_MemProps.memoryTypes[memoryTypeIndex].propertyFlags;
 }
 
-void vmaSetCurrentFrameIndex(
+DECLSPEC void VMACALL vmaSetCurrentFrameIndex(
     VmaAllocator allocator,
     uint32_t frameIndex)
 {
@@ -15816,7 +15824,7 @@ void vmaSetCurrentFrameIndex(
     allocator->SetCurrentFrameIndex(frameIndex);
 }
 
-void vmaCalculateStats(
+DECLSPEC void VMACALL vmaCalculateStats(
     VmaAllocator allocator,
     VmaStats* pStats)
 {
@@ -15827,7 +15835,7 @@ void vmaCalculateStats(
 
 #if VMA_STATS_STRING_ENABLED
 
-void vmaBuildStatsString(
+DECLSPEC void VMACALL vmaBuildStatsString(
     VmaAllocator allocator,
     char** ppStatsString,
     VkBool32 detailedMap)
@@ -15935,7 +15943,7 @@ void vmaBuildStatsString(
     *ppStatsString = pChars;
 }
 
-void vmaFreeStatsString(
+DECLSPEC void VMACALL vmaFreeStatsString(
     VmaAllocator allocator,
     char* pStatsString)
 {
@@ -15952,7 +15960,7 @@ void vmaFreeStatsString(
 /*
 This function is not protected by any mutex because it just reads immutable data.
 */
-VkResult vmaFindMemoryTypeIndex(
+DECLSPEC VkResult VMACALL vmaFindMemoryTypeIndex(
     VmaAllocator allocator,
     uint32_t memoryTypeBits,
     const VmaAllocationCreateInfo* pAllocationCreateInfo,
@@ -16031,7 +16039,7 @@ VkResult vmaFindMemoryTypeIndex(
     return (*pMemoryTypeIndex != UINT32_MAX) ? VK_SUCCESS : VK_ERROR_FEATURE_NOT_PRESENT;
 }
 
-VkResult vmaFindMemoryTypeIndexForBufferInfo(
+DECLSPEC VkResult VMACALL vmaFindMemoryTypeIndexForBufferInfo(
     VmaAllocator allocator,
     const VkBufferCreateInfo* pBufferCreateInfo,
     const VmaAllocationCreateInfo* pAllocationCreateInfo,
@@ -16064,7 +16072,7 @@ VkResult vmaFindMemoryTypeIndexForBufferInfo(
     return res;
 }
 
-VkResult vmaFindMemoryTypeIndexForImageInfo(
+DECLSPEC VkResult VMACALL vmaFindMemoryTypeIndexForImageInfo(
     VmaAllocator allocator,
     const VkImageCreateInfo* pImageCreateInfo,
     const VmaAllocationCreateInfo* pAllocationCreateInfo,
@@ -16097,7 +16105,7 @@ VkResult vmaFindMemoryTypeIndexForImageInfo(
     return res;
 }
 
-VkResult vmaCreatePool(
+DECLSPEC VkResult VMACALL vmaCreatePool(
 	VmaAllocator allocator,
 	const VmaPoolCreateInfo* pCreateInfo,
 	VmaPool* pPool)
@@ -16120,7 +16128,7 @@ VkResult vmaCreatePool(
     return res;
 }
 
-void vmaDestroyPool(
+DECLSPEC void VMACALL vmaDestroyPool(
     VmaAllocator allocator,
     VmaPool pool)
 {
@@ -16145,7 +16153,7 @@ void vmaDestroyPool(
     allocator->DestroyPool(pool);
 }
 
-void vmaGetPoolStats(
+DECLSPEC void VMACALL vmaGetPoolStats(
     VmaAllocator allocator,
     VmaPool pool,
     VmaPoolStats* pPoolStats)
@@ -16157,7 +16165,7 @@ void vmaGetPoolStats(
     allocator->GetPoolStats(pool, pPoolStats);
 }
 
-void vmaMakePoolAllocationsLost(
+DECLSPEC void VMACALL vmaMakePoolAllocationsLost(
     VmaAllocator allocator,
     VmaPool pool,
     size_t* pLostAllocationCount)
@@ -16176,7 +16184,7 @@ void vmaMakePoolAllocationsLost(
     allocator->MakePoolAllocationsLost(pool, pLostAllocationCount);
 }
 
-VkResult vmaCheckPoolCorruption(VmaAllocator allocator, VmaPool pool)
+DECLSPEC VkResult VMACALL vmaCheckPoolCorruption(VmaAllocator allocator, VmaPool pool)
 {
     VMA_ASSERT(allocator && pool);
 
@@ -16187,7 +16195,7 @@ VkResult vmaCheckPoolCorruption(VmaAllocator allocator, VmaPool pool)
     return allocator->CheckPoolCorruption(pool);
 }
 
-VkResult vmaAllocateMemory(
+DECLSPEC VkResult VMACALL vmaAllocateMemory(
     VmaAllocator allocator,
     const VkMemoryRequirements* pVkMemoryRequirements,
     const VmaAllocationCreateInfo* pCreateInfo,
@@ -16230,7 +16238,7 @@ VkResult vmaAllocateMemory(
 	return result;
 }
 
-VkResult vmaAllocateMemoryPages(
+DECLSPEC VkResult VMACALL vmaAllocateMemoryPages(
     VmaAllocator allocator,
     const VkMemoryRequirements* pVkMemoryRequirements,
     const VmaAllocationCreateInfo* pCreateInfo,
@@ -16283,7 +16291,7 @@ VkResult vmaAllocateMemoryPages(
 	return result;
 }
 
-VkResult vmaAllocateMemoryForBuffer(
+DECLSPEC VkResult VMACALL vmaAllocateMemoryForBuffer(
     VmaAllocator allocator,
     VkBuffer buffer,
     const VmaAllocationCreateInfo* pCreateInfo,
@@ -16335,7 +16343,7 @@ VkResult vmaAllocateMemoryForBuffer(
 	return result;
 }
 
-VkResult vmaAllocateMemoryForImage(
+DECLSPEC VkResult VMACALL vmaAllocateMemoryForImage(
     VmaAllocator allocator,
     VkImage image,
     const VmaAllocationCreateInfo* pCreateInfo,
@@ -16386,7 +16394,7 @@ VkResult vmaAllocateMemoryForImage(
 	return result;
 }
 
-void vmaFreeMemory(
+DECLSPEC void VMACALL vmaFreeMemory(
     VmaAllocator allocator,
     VmaAllocation allocation)
 {
@@ -16415,7 +16423,7 @@ void vmaFreeMemory(
         &allocation);
 }
 
-void vmaFreeMemoryPages(
+DECLSPEC void VMACALL vmaFreeMemoryPages(
     VmaAllocator allocator,
     size_t allocationCount,
     VmaAllocation* pAllocations)
@@ -16444,7 +16452,7 @@ void vmaFreeMemoryPages(
     allocator->FreeMemory(allocationCount, pAllocations);
 }
 
-VkResult vmaResizeAllocation(
+DECLSPEC VkResult VMACALL vmaResizeAllocation(
     VmaAllocator allocator,
     VmaAllocation allocation,
     VkDeviceSize newSize)
@@ -16458,7 +16466,7 @@ VkResult vmaResizeAllocation(
     return allocator->ResizeAllocation(allocation, newSize);
 }
 
-void vmaGetAllocationInfo(
+DECLSPEC void VMACALL vmaGetAllocationInfo(
     VmaAllocator allocator,
     VmaAllocation allocation,
     VmaAllocationInfo* pAllocationInfo)
@@ -16479,7 +16487,7 @@ void vmaGetAllocationInfo(
     allocator->GetAllocationInfo(allocation, pAllocationInfo);
 }
 
-VkBool32 vmaTouchAllocation(
+DECLSPEC VkBool32 VMACALL vmaTouchAllocation(
     VmaAllocator allocator,
     VmaAllocation allocation)
 {
@@ -16499,7 +16507,7 @@ VkBool32 vmaTouchAllocation(
     return allocator->TouchAllocation(allocation);
 }
 
-void vmaSetAllocationUserData(
+DECLSPEC void VMACALL vmaSetAllocationUserData(
     VmaAllocator allocator,
     VmaAllocation allocation,
     void* pUserData)
@@ -16521,7 +16529,7 @@ void vmaSetAllocationUserData(
 #endif
 }
 
-void vmaCreateLostAllocation(
+DECLSPEC void VMACALL vmaCreateLostAllocation(
     VmaAllocator allocator,
     VmaAllocation* pAllocation)
 {
@@ -16541,7 +16549,7 @@ void vmaCreateLostAllocation(
 #endif
 }
 
-VkResult vmaMapMemory(
+DECLSPEC VkResult VMACALL vmaMapMemory(
     VmaAllocator allocator,
     VmaAllocation allocation,
     void** ppData)
@@ -16564,7 +16572,7 @@ VkResult vmaMapMemory(
     return res;
 }
 
-void vmaUnmapMemory(
+DECLSPEC void VMACALL vmaUnmapMemory(
     VmaAllocator allocator,
     VmaAllocation allocation)
 {
@@ -16584,7 +16592,7 @@ void vmaUnmapMemory(
     allocator->Unmap(allocation);
 }
 
-void vmaFlushAllocation(VmaAllocator allocator, VmaAllocation allocation, VkDeviceSize offset, VkDeviceSize size)
+DECLSPEC void VMACALL vmaFlushAllocation(VmaAllocator allocator, VmaAllocation allocation, VkDeviceSize offset, VkDeviceSize size)
 {
     VMA_ASSERT(allocator && allocation);
 
@@ -16604,7 +16612,7 @@ void vmaFlushAllocation(VmaAllocator allocator, VmaAllocation allocation, VkDevi
 #endif
 }
 
-void vmaInvalidateAllocation(VmaAllocator allocator, VmaAllocation allocation, VkDeviceSize offset, VkDeviceSize size)
+DECLSPEC void VMACALL vmaInvalidateAllocation(VmaAllocator allocator, VmaAllocation allocation, VkDeviceSize offset, VkDeviceSize size)
 {
     VMA_ASSERT(allocator && allocation);
 
@@ -16624,7 +16632,7 @@ void vmaInvalidateAllocation(VmaAllocator allocator, VmaAllocation allocation, V
 #endif
 }
 
-VkResult vmaCheckCorruption(VmaAllocator allocator, uint32_t memoryTypeBits)
+DECLSPEC VkResult VMACALL vmaCheckCorruption(VmaAllocator allocator, uint32_t memoryTypeBits)
 {
     VMA_ASSERT(allocator);
 
@@ -16635,7 +16643,7 @@ VkResult vmaCheckCorruption(VmaAllocator allocator, uint32_t memoryTypeBits)
     return allocator->CheckCorruption(memoryTypeBits);
 }
 
-VkResult vmaDefragment(
+DECLSPEC VkResult VMACALL vmaDefragment(
     VmaAllocator allocator,
     VmaAllocation* pAllocations,
     size_t allocationCount,
@@ -16670,7 +16678,7 @@ VkResult vmaDefragment(
     return res;
 }
 
-VkResult vmaDefragmentationBegin(
+DECLSPEC VkResult VMACALL vmaDefragmentationBegin(
     VmaAllocator allocator,
     const VmaDefragmentationInfo2* pInfo,
     VmaDefragmentationStats* pStats,
@@ -16706,7 +16714,7 @@ VkResult vmaDefragmentationBegin(
     return res;
 }
 
-VkResult vmaDefragmentationEnd(
+DECLSPEC VkResult VMACALL vmaDefragmentationEnd(
     VmaAllocator allocator,
     VmaDefragmentationContext context)
 {
@@ -16734,7 +16742,7 @@ VkResult vmaDefragmentationEnd(
     }
 }
 
-VkResult vmaBindBufferMemory(
+DECLSPEC VkResult VMACALL vmaBindBufferMemory(
     VmaAllocator allocator,
     VmaAllocation allocation,
     VkBuffer buffer)
@@ -16748,7 +16756,7 @@ VkResult vmaBindBufferMemory(
     return allocator->BindBufferMemory(allocation, 0, buffer, VMA_NULL);
 }
 
-VkResult vmaBindBufferMemory2(
+DECLSPEC VkResult VMACALL vmaBindBufferMemory2(
     VmaAllocator allocator,
     VmaAllocation allocation,
     VkDeviceSize allocationLocalOffset,
@@ -16764,7 +16772,7 @@ VkResult vmaBindBufferMemory2(
     return allocator->BindBufferMemory(allocation, allocationLocalOffset, buffer, pNext);
 }
 
-VkResult vmaBindImageMemory(
+DECLSPEC VkResult VMACALL vmaBindImageMemory(
     VmaAllocator allocator,
     VmaAllocation allocation,
     VkImage image)
@@ -16778,7 +16786,7 @@ VkResult vmaBindImageMemory(
     return allocator->BindImageMemory(allocation, 0, image, VMA_NULL);
 }
 
-VkResult vmaBindImageMemory2(
+DECLSPEC VkResult VMACALL vmaBindImageMemory2(
     VmaAllocator allocator,
     VmaAllocation allocation,
     VkDeviceSize allocationLocalOffset,
@@ -16794,7 +16802,7 @@ VkResult vmaBindImageMemory2(
         return allocator->BindImageMemory(allocation, allocationLocalOffset, image, pNext);
 }
 
-VkResult vmaCreateBuffer(
+DECLSPEC VkResult VMACALL vmaCreateBuffer(
     VmaAllocator allocator,
     const VkBufferCreateInfo* pBufferCreateInfo,
     const VmaAllocationCreateInfo* pAllocationCreateInfo,
@@ -16907,7 +16915,7 @@ VkResult vmaCreateBuffer(
     return res;
 }
 
-void vmaDestroyBuffer(
+DECLSPEC void VMACALL vmaDestroyBuffer(
     VmaAllocator allocator,
     VkBuffer buffer,
     VmaAllocation allocation)
@@ -16945,7 +16953,7 @@ void vmaDestroyBuffer(
     }
 }
 
-VkResult vmaCreateImage(
+DECLSPEC VkResult VMACALL vmaCreateImage(
     VmaAllocator allocator,
     const VkImageCreateInfo* pImageCreateInfo,
     const VmaAllocationCreateInfo* pAllocationCreateInfo,
@@ -17047,7 +17055,7 @@ VkResult vmaCreateImage(
     return res;
 }
 
-void vmaDestroyImage(
+DECLSPEC void VMACALL vmaDestroyImage(
     VmaAllocator allocator,
     VkImage image,
     VmaAllocation allocation)


### PR DESCRIPTION
Hi there! I'm developing a Vulkan graphics backend for a C# game framework, and I would very much like to use VMA for memory management. However, I quickly found out that there is no way to directly use VMA with C# on Windows. For obvious reasons I can't include the header file in my project, and even if the library is compiled as a DLL, the functions aren't exported. So I wrote up a fix!

This PR adds a new define (`VMA_STANDALONE`) that will export all the API functions (via `__declspec(dllexport)`) with the C calling convention (`__cdecl`), wrapped into easily modifiable macros. With these changes, it's simple to build the library into a standalone DLL for consumption on Windows.

Not sure if this benefits other platforms or not, but it works great for Windows. Thanks to the code in this PR, I've been able to write a [C# binding library](https://github.com/TheSpydog/VMA-CS) and use it without issue (so far)! :smile: