### PR TITLE
Added clang compile support on windows

### DIFF
--- a/src/VmaUsage.h
+++ b/src/VmaUsage.h
@@ -30,6 +30,14 @@
 #include <Windows.h>
 #define VK_USE_PLATFORM_WIN32_KHR
 
+#else  // #ifdef _WIN32
+
+#include <vulkan/vulkan.h>
+
+#endif  // #ifdef _WIN32
+
+#ifdef _MSVC_LANG
+
 // Uncomment to test including `vulkan.h` on your own before including VMA.
 //#include <vulkan/vulkan.h>
 
@@ -62,24 +70,24 @@ include all public interface declarations. Example:
 #pragma warning(disable: 4189) // local variable is initialized but not referenced
 #pragma warning(disable: 4324) // structure was padded due to alignment specifier
 
-#include "vk_mem_alloc.h"
-
-#pragma warning(pop)
-
-#else // #ifdef _WIN32
+#endif  // #ifdef _MSVC_LANG
 
 #ifdef __clang__
     #pragma clang diagnostic push
     #pragma clang diagnostic ignored "-Wtautological-compare" // comparison of unsigned expression < 0 is always false
+    #pragma clang diagnostic ignored "-Wunused-private-field"
+    #pragma clang diagnostic ignored "-Wunused-parameter"
+    #pragma clang diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
-#include <vulkan/vulkan.h>
 #include "vk_mem_alloc.h"
 
 #ifdef __clang__
     #pragma clang diagnostic pop
 #endif
 
-#endif // #ifdef _WIN32
+#ifdef _MSVC_LANG
+    #pragma warning(pop)
+#endif
 
 #endif


### PR DESCRIPTION
With this change the llvm\clang-cl.exe can compile the Vma with warning level 4.