### PR TITLE
AllocateVulkanMemory() trashes budget block bytes and has a potential deadlock

### DIFF
--- a/src/vk_mem_alloc.h
+++ b/src/vk_mem_alloc.h
@@ -15849,9 +15849,9 @@ VkResult VmaAllocator_T::AllocateVulkanMemory(const VkMemoryAllocateInfo* pAlloc
     if((m_HeapSizeLimitMask & (1u << heapIndex)) != 0)
     {
         const VkDeviceSize heapSize = m_MemProps.memoryHeaps[heapIndex].size;
-        VkDeviceSize blockBytes = m_Budget.m_BlockBytes[heapIndex];
         for(;;)
         {
+            VkDeviceSize blockBytes = m_Budget.m_BlockBytes[heapIndex];
             const VkDeviceSize blockBytesAfterAllocation = blockBytes + pAllocateInfo->allocationSize;
             if(blockBytesAfterAllocation > heapSize)
             {

--- a/src/vk_mem_alloc.h
+++ b/src/vk_mem_alloc.h
@@ -15857,7 +15857,7 @@ VkResult VmaAllocator_T::AllocateVulkanMemory(const VkMemoryAllocateInfo* pAlloc
             {
                 return VK_ERROR_OUT_OF_DEVICE_MEMORY;
             }
-            if(m_Budget.m_BlockBytes->compare_exchange_strong(blockBytes, blockBytesAfterAllocation))
+            if(m_Budget.m_BlockBytes[heapIndex].compare_exchange_strong(blockBytes, blockBytesAfterAllocation))
             {
                 break;
             }


### PR DESCRIPTION
These two issues are only there when running with heap size limits!

In the first case, the `m_BlockBytes` member is accessed as a pointer, so the `compare_and_exchange` only has an effect on the first heap. If the allocation comes from a different heap, then it will always be marked as having 0 bytes (which can lead to an underflow later on when the block is freed, which will result in all future allocations failing).

The second case is a deadlock in the compare exchange loop. If the compare exchange fails, it's because another thread modified `m_BlockBytes`. I'm not 100% sure if this can ever happen or if this is guarded by mutexes, but the `compare_and_exchange` makes it feel like multiple threads can mess around there. I have not actually ran into this, despite trying, unlike the first issue. Anyways, subsequent iterations will also fail because the stale cached `blockBytes` value was used.