### PR TITLE
Prototype for a defragmentation interface that supports tiling optimal images

### DIFF
--- a/src/Tests.cpp
+++ b/src/Tests.cpp
@@ -1514,7 +1514,7 @@ void TestDefragmentationSimple()
     Allocation that must be move to an overlapping place using memmove().
     Create 2 buffers, second slightly bigger than the first. Delete first. Then defragment.
     */
-    if(VMA_DEBUG_MARGIN) // FAST algorithm works only when DEBUG_MARGIN disabled.
+    if(VMA_DEBUG_MARGIN == 0) // FAST algorithm works only when DEBUG_MARGIN disabled.
     {
         AllocInfo allocInfo[2];
 
@@ -6107,13 +6107,6 @@ void Test()
     }
 
     // # Simple tests
-
-#if 1
-    TestDefragmentationIncrementalBasic();
-    TestDefragmentationIncrementalComplex();
-    return;
-#endif
-
     TestBasics();
     //TestGpuData(); // Not calling this because it's just testing the testing environment.
 #if VMA_DEBUG_MARGIN

--- a/src/vk_mem_alloc.h
+++ b/src/vk_mem_alloc.h
@@ -6373,14 +6373,14 @@ struct VmaDefragmentationMove
     VkDeviceSize srcOffset;
     VkDeviceSize dstOffset;
     VkDeviceSize size;
-	VmaAllocation allocation;
-	VmaAllocationType type;
-	void *handle; // VkImage or VkBuffer
-	union
-	{
-		VmaImageIntrospection imageIntrospection;
-		VmaBufferIntrospection bufferIntrospection;
-	};
+    VmaAllocation allocation;
+    VmaAllocationType type;
+    void *handle; // VkImage or VkBuffer
+    union
+    {
+    	VmaImageIntrospection imageIntrospection;
+    	VmaBufferIntrospection bufferIntrospection;
+    };
 };
 
 class VmaDefragmentationAlgorithm;

--- a/src/vk_mem_alloc.h
+++ b/src/vk_mem_alloc.h
@@ -6373,6 +6373,14 @@ struct VmaDefragmentationMove
     VkDeviceSize srcOffset;
     VkDeviceSize dstOffset;
     VkDeviceSize size;
+	VmaAllocation allocation;
+	VmaAllocationType type;
+	void *handle; // VkImage or VkBuffer
+	union
+	{
+		VmaImageIntrospection imageIntrospection;
+		VmaBufferIntrospection bufferIntrospection;
+	};
 };
 
 class VmaDefragmentationAlgorithm;


### PR DESCRIPTION
Hey Adam,

First of all, let me preface this by saying that this is a incomplete pull request for now! But I'm very interested in your feedback on this and to see if you are interested in having this upstream.

Essentially this is the foundational work for defragmentation that supports tiling optimal images. The basic idea is that there is a new defragmentation info `VmaDefragmentationInfo3`, which has support for callbacks that the host can fill in. These callbacks are then used to figure out what kind of allocation something is and other information, such as the create info and barrier information. The only other visible difference is that there now is an `vmaDefragmentationBegin2()` to go along with it.

My goal was to make this as little intrusive as possible, all of the old schemes still work and they work the exact same way as before. Almost none of the public interfaces have been touched, and I tried to also minimize the code changes internally.

When defragmenting, VMA still does all the same work to figure out where to move new allocations. The big difference comes at execution time (see `ApplyDefragmentationMovesGpu`). Here, VMA will interrogate the host in order to figure out where the resource is used and what image layout it is in. Then VMA will create a new image, bind it to the new memory location, and do the copying & pipeline barriers necessary to synchronize everything. Because of the way images are handled, creating and binding a new image is also no longer in the responsibility of the host application, but they are provided with another callback to let them know that a resource has changed.

For an example of this, take a look at the modified Tests.cpp which has an `TestDefragmentationImagesGpu()` function that tests the new interface.

There are a bunch of open issues that I'm left with:

- [x] No support for buffers. My thought is to provide the exact same interface as for images, and most of it is already there, except for the execution part
- [x] There is a callback to interrogate the host about the type of resource, but VMA already knows this internally from the `VmaSuballocationType`. This mainly was my idea to make this an opt-in interface, but I'm not sure if this makes for a better or worse API.
- [x] Because of the way it works, it requires a command buffer. Which is at odds with how defragmentation works on the CPU. Then again, tiling optimal images might not really be something you ever have on the CPU, so it might be okay to have this be GPU only?
- [ ] Documentation! VMA is great because it has excellent documentation, and I documented basically nothing yet.
- [ ] Bit of clean up and whitespace issues

Anyways, my question is essentially: What are your thoughts on this? Would you be interested in this upstream? And if so, what are your thoughts on the API proposal?