### PR TITLE
Fix C++17 shared_mutex compile error

### DIFF
--- a/src/vk_mem_alloc.h
+++ b/src/vk_mem_alloc.h
@@ -3715,7 +3715,7 @@ void *aligned_alloc(size_t alignment, size_t size)
         public:
             void LockRead() { m_Mutex.lock_shared(); }
             void UnlockRead() { m_Mutex.unlock_shared(); }
-            bool TryLockRead() { return m_Mutex.try_shared_lock(); }
+            bool TryLockRead() { return m_Mutex.try_lock_shared(); }
             void LockWrite() { m_Mutex.lock(); }
             void UnlockWrite() { m_Mutex.unlock(); }
             bool TryLockWrite() { return m_Mutex.try_lock(); }


### PR DESCRIPTION
In C++17 the method is called: https://en.cppreference.com/w/cpp/thread/shared_mutex/try_lock_shared