### PR TITLE
Fixed incorrect for loop in ProcessDefragmetnations()

### DIFF
--- a/src/vk_mem_alloc.h
+++ b/src/vk_mem_alloc.h
@@ -13019,9 +13019,9 @@ uint32_t VmaBlockVector::ProcessDefragmentations(
     
     const uint32_t moveCount = std::min(uint32_t(pCtx->defragmentationMoves.size()) - pCtx->defragmentationMovesProcessed, maxMoves);
 
-    for(uint32_t i = pCtx->defragmentationMovesProcessed; i < moveCount; ++ i)
+    for(uint32_t i = 0; i < moveCount; ++ i)
     {
-        VmaDefragmentationMove& move = pCtx->defragmentationMoves[i];
+        VmaDefragmentationMove& move = pCtx->defragmentationMoves[pCtx->defragmentationMovesProcessed + i];
 
         pMove->allocation = move.hAllocation;
         pMove->memory = move.pDstBlock->GetDeviceMemory();


### PR DESCRIPTION
Basically what the title says. The loops completely fails, which prevents VMA from being able to use multiple defragmentation passes to just move a subset of the data (eg. throw 10k objects at the defragmenter, and then do 10 passes with a `moveCount` of just 1000)