### PR TITLE
Exposing notPreferredFlags from vmaFindMemoryTypeIndex() in VmaAllocationCreateInfo

### DIFF
--- a/src/vk_mem_alloc.h
+++ b/src/vk_mem_alloc.h
@@ -2629,6 +2629,11 @@ typedef struct VmaAllocationCreateInfo
     Set to 0 if no additional flags are prefered. \n
     If `pool` is not null, this member is ignored. */
     VkMemoryPropertyFlags preferredFlags;
+    /** \brief Flags that preferably should *not* be set in a memory type chosen for an allocation.
+
+    Set to 0 if any flags are okay. \n
+    If `pool` is not null, this member is ignored. */
+    VkMemoryPropertyFlags notPreferredFlags;
     /** \brief Bitmask containing one bit set for every memory type acceptable for this allocation.
 
     Value 0 is equivalent to `UINT32_MAX` - it means any memory type is accepted if
@@ -17253,7 +17258,7 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaFindMemoryTypeIndex(
     
     uint32_t requiredFlags = pAllocationCreateInfo->requiredFlags;
     uint32_t preferredFlags = pAllocationCreateInfo->preferredFlags;
-    uint32_t notPreferredFlags = 0;
+    uint32_t notPreferredFlags = pAllocationCreateInfo->notPreferredFlags;
 
     // Convert usage to requiredFlags and preferredFlags.
     switch(pAllocationCreateInfo->usage)
@@ -17297,6 +17302,10 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaFindMemoryTypeIndex(
     {
         notPreferredFlags |= VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD_COPY;
     }
+
+	// Avoid requesting any of the non preferred flags
+    requiredFlags &= ~notPreferredFlags;
+    preferredFlags &= ~notPreferredFlags;
 
     *pMemoryTypeIndex = UINT32_MAX;
     uint32_t minCost = UINT32_MAX;


### PR DESCRIPTION
Pretty minor change all things considered. The reason that I've added this is because sometimes it might be desirable to explicitly prefer _not_ to have a specific kind of memory property. For example in our case, we don't want `HOST_COHERENT` memory ever on the current Nvidia drivers and there was no good way to achieve this previously. We don't want to lie to VMA about our usage and use that to get memory with different properties.

The Nvidia case is mostly down to the Nvidia driver taking a lock when making an allocation and holding it for the whole duration of the request. This would normally be totally okay, but it turns out that requesting write combined memory will force the NT kernel to walk the page table entry for all 256mb (with default VMA settings) of memory and setting the write combined flag. This can take up to 80ms on my system, which means the driver holds that lock for 80ms. The big problem is that other operations like submitting a command buffer to a queue _also_ take the very same lock, so we end up with the renderer pausing mid frame for 80 or so ms which is not acceptable for our real time requirements.

This is our concrete use case for this feature. Even with fixed Nvidia drivers in the future, we'll have to maintain this work around at least for some while. I'm sure there are other use cases for this feature, so I figured I might as well create a pull request for it. Obviously this breaks API in _some_ way (assuming some people don't 0 initialize the `VmaAllocationCreateInfo` struct), so you are very welcome to reject this if you prefer to stay compatible.