### PR TITLE
Fix Clang implicit fallthrough warning.

### DIFF
--- a/src/vk_mem_alloc.h
+++ b/src/vk_mem_alloc.h
@@ -1993,6 +1993,13 @@ available through VmaAllocatorCreateInfo::pRecordSettings.
     #define VMA_CALL_POST
 #endif
 
+// Used to silence warnings for implicit fallthrough.
+#if __has_cpp_attribute(clang::fallthrough)
+#define VMA_FALLTHROUGH [[clang::fallthrough]];
+#else
+#define VMA_FALLTHROUGH
+#endif
+
 /** \struct VmaAllocator
 \brief Represents main object of this library initialized.
 
@@ -11834,6 +11841,7 @@ void VmaDeviceMemoryBlock::Init(
     default:
         VMA_ASSERT(0);
         // Fall-through.
+        VMA_FALLTHROUGH
     case 0:
         m_pMetadata = vma_new(hAllocator, VmaBlockMetadata_Generic)(hAllocator);
     }


### PR DESCRIPTION
This uses the [[clang:fallthrough]] tag to silence the warning in
VmaDeviceMemoryBlock::Init. Note that there is also a C++17 attribute.
However C++17 isn't available to some projects.

Fixes #112

@adam-sawicki-a  Please take a look.