### PR TITLE
Update quick start docs to reflect that instance is not optional

### DIFF
--- a/src/vk_mem_alloc.h
+++ b/src/vk_mem_alloc.h
@@ -146,7 +146,7 @@ them before every `#include` of this library.
 
 At program startup:
 
--# Initialize Vulkan to have `VkPhysicalDevice` and `VkDevice` object.
+-# Initialize Vulkan to have `VkPhysicalDevice`, `VkDevice` and `VkInstance` object.
 -# Fill VmaAllocatorCreateInfo structure and create #VmaAllocator object by
    calling vmaCreateAllocator().
 
@@ -154,6 +154,7 @@ At program startup:
 VmaAllocatorCreateInfo allocatorInfo = {};
 allocatorInfo.physicalDevice = physicalDevice;
 allocatorInfo.device = device;
+allocatorInfo.instance = instance;
 
 VmaAllocator allocator;
 vmaCreateAllocator(&allocatorInfo, &allocator);


### PR DESCRIPTION
The quick start guide provides a minimal example of instantiating a `VmaAllocator`. Unfortunately the example is incorrect, as the `instance` field (type `VkInstance`) in the `VmaAllocatorCreateInfo` struct is not optional anymore. 

Without providing a value for this field the user hits the assert on line 15503:
`VmaAllocator_T::VmaAllocator_T(const VmaAllocatorCreateInfo*): Assertion pCreateInfo->physicalDevice && pCreateInfo->device && pCreateInfo->instance' failed.`

This small PR updates the quick start docs to reflect this.