### PR TITLE
Move some preprocessor directives that may influence user code into "implementation" block

### DIFF
--- a/src/vk_mem_alloc.h
+++ b/src/vk_mem_alloc.h
@@ -2000,16 +2000,6 @@ Features deliberately excluded from the scope of this library:
 
 */
 
-#if VMA_RECORDING_ENABLED
-    #include <chrono>
-    #if defined(_WIN32)
-        #include <windows.h>
-    #else
-        #include <sstream>
-        #include <thread>
-    #endif
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -2022,7 +2012,7 @@ available through VmaAllocatorCreateInfo::pRecordSettings.
     #define VMA_RECORDING_ENABLED 0
 #endif
 
-#ifndef NOMINMAX
+#if !defined(NOMINMAX) && defined(VMA_IMPLEMENTATION)
     #define NOMINMAX // For windows.h
 #endif
 
@@ -3965,6 +3955,16 @@ VMA_CALL_PRE void VMA_CALL_POST vmaDestroyImage(
 #include <cstdlib>
 #include <cstring>
 #include <utility>
+
+#if VMA_RECORDING_ENABLED
+    #include <chrono>
+    #if defined(_WIN32)
+        #include <windows.h>
+    #else
+        #include <sstream>
+        #include <thread>
+    #endif
+#endif
 
 /*******************************************************************************
 CONFIGURATION SECTION


### PR DESCRIPTION
These fix a bit of "namespace pollution" caused by vk_mem_alloc.h. Nothing really dramatic, but I noticed them by chance...

NOMINMAX - this would have been defined in any source file including vk_mem_alloc.h. Granted, a lot of people probably define NOMINMAX anyway, and there aren't that many sane reasons to not do that... but strictly speaking, having this define will change how some (unrelated) user code may be interpreted, and thus that little bit of control should be left to them as well. Since VMA only needs that option in the "implementation" part, limit the definition's scope to that.

Similarly, defining VMA_RECORDING_ENABLED pulls in a number of headers which are only really needed in the implementation part, so move the includes there.