### PR TITLE
Make binary search overflow safe

### DIFF
--- a/src/vk_mem_alloc.h
+++ b/src/vk_mem_alloc.h
@@ -4721,7 +4721,7 @@ static IterT VmaBinaryFindFirstNotLess(IterT beg, IterT end, const KeyT &key, co
     size_t down = 0, up = (end - beg);
     while(down < up)
     {
-        const size_t mid = (down + up) / 2;
+        const size_t mid = down + (up - down) / 2;  // Overflow-safe midpoint calculation
         if(cmp(*(beg+mid), key))
         {
             down = mid + 1;


### PR DESCRIPTION
Our internal static analysis flags potentially unsafe midpoint
calculations. The proposed fix ensures the binary search doesn't
overflow at the cost of a single additional operation.