### PR TITLE
Fix clang -Wdeprecated-copy.

### DIFF
--- a/include/vk_mem_alloc.h
+++ b/include/vk_mem_alloc.h
@@ -4963,6 +4963,7 @@ public:
     }
 
     VmaStlAllocator& operator=(const VmaStlAllocator& x) = delete;
+    VmaStlAllocator(const VmaStlAllocator&) = default;
 };
 
 #if VMA_USE_STL_VECTOR


### PR DESCRIPTION
The copy constructor must be explicitly defined (here, defaulted) to be
available when the assignment operator is deleted.  While there is a
templated constructor from VmaStlAllocator<U>, the compiler doesn't
consider this to be a "copy" constructor for purposes of the warning.