### PR TITLE
Add include_directories to CMake to include the header files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.9)
 project(VulkanMemoryAllocator)
 
 find_package(Vulkan REQUIRED)
+include_directories(${Vulkan_INCLUDE_DIR})
 
 # VulkanMemoryAllocator contains an sample application and VmaReplay which are not build by default
 option(VMA_BUILD_SAMPLE "Build VulkanMemoryAllocator sample application" OFF)


### PR DESCRIPTION
This change makes sure the right vulkan headers can be include using `#include<vulkan/vulkan.h>` and makes sure that the imported headers are those from FindPackage() rather than those found in system include paths. (Currently VMA does not build on macOS for example as the default header paths do not include vulkan headers, even when sdk is installed correctly.)