### PR TITLE
Do not fail travis build if the build directory already exists.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - export VULKAN_SDK=$TRAVIS_BUILD_DIR/$VK_VERSION/x86_64
 
 script:
-  - mkdir build
+  - mkdir -p build
   - cd build
   - cmake ..
   - make


### PR DESCRIPTION
Linux build failed because the build directory already exists,. Now the build will be really done so it's possible there is some other cause of failure for a travis linux build.