### PR TITLE
Compatibility fix with old sdks where VK_ERROR_UNKNOWN is not defined

### DIFF
--- a/include/vk_mem_alloc.h
+++ b/include/vk_mem_alloc.h
@@ -150,6 +150,10 @@ available through VmaAllocatorCreateInfo::pRecordSettings.
     #include <vulkan/vulkan.h>
 #endif
 
+#if !defined(VK_VERSION_1_2)
+    #define VK_ERROR_UNKNOWN ((VkResult)-13)
+#endif
+
 // Define this macro to declare maximum supported Vulkan version in format AAABBBCCC,
 // where AAA = major, BBB = minor, CCC = patch.
 // If you want to use version > 1.0, it still needs to be enabled via VmaAllocatorCreateInfo::vulkanApiVersion.


### PR DESCRIPTION
`VK_ERROR_UNKNOWN` was added in the first Vulkan 1.2 SDK (https://github.com/KhronosGroup/Vulkan-Headers/releases/tag/v1.2.131). The define is to maintain the compatibility with the previous sdks.