### PR TITLE
fix crash in VmaAllocator_T::AllocateDedicatedMemory

### DIFF
--- a/include/vk_mem_alloc.h
+++ b/include/vk_mem_alloc.h
@@ -15493,9 +15493,9 @@ VkResult VmaAllocator_T::AllocateDedicatedMemory(
     allocInfo.allocationSize = size;
 
 #if VMA_DEDICATED_ALLOCATION || VMA_VULKAN_VERSION >= 1001000
+    VkMemoryDedicatedAllocateInfoKHR dedicatedAllocInfo = { VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO_KHR };
     if(!canAliasMemory)
     {
-        VkMemoryDedicatedAllocateInfoKHR dedicatedAllocInfo = { VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO_KHR };
         if(m_UseKhrDedicatedAllocation || m_VulkanApiVersion >= VK_MAKE_VERSION(1, 1, 0))
         {
             if(dedicatedBuffer != VK_NULL_HANDLE)


### PR DESCRIPTION
move variable dedicatedAllocInfo outside the if block in case of destruct of dedicatedAllocInfo
https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/blob/master/include/vk_mem_alloc.h#L15498