### PR TITLE
Fix MSVC warning C4505 for VmaCreateStringCopy

### DIFF
--- a/include/vk_mem_alloc.h
+++ b/include/vk_mem_alloc.h
@@ -3256,6 +3256,7 @@ static char* VmaCreateStringCopy(const VkAllocationCallbacks* allocs, const char
     return VMA_NULL;
 }
 
+#if VMA_STATS_STRING_ENABLED
 static char* VmaCreateStringCopy(const VkAllocationCallbacks* allocs, const char* srcStr, size_t strLen)
 {
     if (srcStr != VMA_NULL)
@@ -3267,6 +3268,7 @@ static char* VmaCreateStringCopy(const VkAllocationCallbacks* allocs, const char
     }
     return VMA_NULL;
 }
+#endif // VMA_STATS_STRING_ENABLED
 
 static void VmaFreeString(const VkAllocationCallbacks* allocs, char* str)
 {


### PR DESCRIPTION
The overloaded signature of `VmaCreateStringCopy` with a `size_t strLen` argument is only used together with `VmaStringBuilder` (in lines [15154](https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/blob/4f24cf28c8f48fb1c140f183d037211ef2fe39ca/include/vk_mem_alloc.h#L15154) and [16370](https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/blob/4f24cf28c8f48fb1c140f183d037211ef2fe39ca/include/vk_mem_alloc.h#L16370)). So, if we `#define VMA_STATS_STRING_ENABLED 0` it is still declared but no longer used.

This triggers an "[unreferenced local function has been removed](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4505?view=msvc-170)" warning on MSVC when compiling with `/W4`.

This PR wraps the overload declaration with an `#if VMA_STATS_STRING_ENABLED ... #endif` to fix it.