### PR TITLE
Fix VMA_STATS_STRING_ENABLED 0 with VMA_DEBUG_LOG

### DIFF
--- a/include/vk_mem_alloc.h
+++ b/include/vk_mem_alloc.h
@@ -6048,6 +6048,8 @@ void VmaBlockMetadata::DebugLogAllocation(VkDeviceSize offset, VkDeviceSize size
         VmaAllocation allocation = reinterpret_cast<VmaAllocation>(userData);
 
         userData = allocation->GetUserData();
+
+#if VMA_STATS_STRING_ENABLED
         if (userData != VMA_NULL && allocation->IsUserDataString())
         {
             VMA_DEBUG_LOG("UNFREED ALLOCATION; Offset: %llu; Size: %llu; UserData: %s; Type: %s; Usage: %u",
@@ -6062,6 +6064,18 @@ void VmaBlockMetadata::DebugLogAllocation(VkDeviceSize offset, VkDeviceSize size
                 VMA_SUBALLOCATION_TYPE_NAMES[allocation->GetSuballocationType()],
                 allocation->GetBufferImageUsage());
         }
+#else
+        if (userData != VMA_NULL && allocation->IsUserDataString())
+        {
+            VMA_DEBUG_LOG("UNFREED ALLOCATION; Offset: %llu; Size: %llu; UserData: %s",
+                offset, size, reinterpret_cast<const char*>(userData));
+        }
+        else
+        {
+            VMA_DEBUG_LOG("UNFREED ALLOCATION; Offset: %llu; Size: %llu; UserData: %p",
+                offset, size, userData);
+        }
+#endif // VMA_STATS_STRING_ENABLED
     }
     
 }


### PR DESCRIPTION
After commit https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/commit/12d128d8f7f5dd1752eec5a644e6aa7eb21efd89, if we `#define VMA_STATS_STRING_ENABLED 0` and also add a custom definition for `VMA_DEBUG_LOG`, we then hit a compilation error:
```
vk_mem_alloc.h(6053,1): error C2065: 'VMA_SUBALLOCATION_TYPE_NAMES': undeclared identifier
vk_mem_alloc.h(6053,1): error C2039: 'GetBufferImageUsage': is not a member of 'VmaAllocation_T'
vk_mem_alloc.h(5613): message : see declaration of 'VmaAllocation_T'
vk_mem_alloc.h(6053,1): warning C4473: 'printf' : not enough arguments passed for format string
vk_mem_alloc.h(6053,1): message : placeholders and their parameters expect 5 variadic arguments, but 3 were provided
vk_mem_alloc.h(6053,1): message : the missing variadic argument 4 is required by format string '%s'
```
(the exact same errors are also reported for line `6060`, but I've omitted them for brevity).

This PR wraps the calls with an `#if VMA_STATS_STRING_ENABLED ... #endif`, only logging `Type: %s; Usage: %u` when it is enabled.