### PR TITLE
Proposal: allow custom includes without having to edit vk_mem_alloc.h

### DIFF
--- a/include/vk_mem_alloc.h
+++ b/include/vk_mem_alloc.h
@@ -2533,12 +2533,33 @@ VmaAllocatorCreateInfo::pVulkanFunctions. Other members can be null.
 #endif
 
 /*
-Following headers are used in this CONFIGURATION section only, so feel free to
+Define this macro to include custom header files without having to edit this file directly, e.g.:
+
+    // Inside of "my_vma_configuration_user_includes.h":
+
+    #include "my_custom_assert.h" // for MY_CUSTOM_ASSERT
+    #include "my_custom_min.h" // for my_custom_min
+    #include <algorithm>
+    #include <mutex>
+
+    // Inside a different file, which includes "vk_mem_alloc.h":
+
+    #define VMA_CONFIGURATION_USER_INCLUDES_H "my_vma_configuration_user_includes.h"
+    #define VMA_ASSERT(expr) MY_CUSTOM_ASSERT(expr)
+    #define VMA_MIN(v1, v2)  (my_custom_min(v1, v2))
+    #include "vk_mem_alloc.h"
+    ...
+
+The following headers are used in this CONFIGURATION section only, so feel free to
 remove them if not needed.
 */
-#include <cassert> // for assert
-#include <algorithm> // for min, max
-#include <mutex>
+#if !defined(VMA_CONFIGURATION_USER_INCLUDES_H)
+    #include <cassert> // for assert
+    #include <algorithm> // for min, max
+    #include <mutex>
+#else
+    #include VMA_CONFIGURATION_USER_INCLUDES_H
+#endif
 
 #ifndef VMA_NULL
    // Value used as null pointer. Define it to e.g.: nullptr, NULL, 0, (void*)0.


### PR DESCRIPTION
Currently, if someone whishes to redefine the macros in the `CONFIGURATION SECTION` they may need to edit "vk_mem_alloc.h" or to be careful to always include a custom header file before it. This might even make some of the currently included headers unnecessary, as it is already noted:
https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/blob/08759cbec52557f46f53f77bfd1e6bf59188c643/include/vk_mem_alloc.h#L2535-L2541

By adding a new `VMA_CONFIGURATION_USER_INCLUDES_H` macro, which defines the path to a user-configured header file, users are no longer required to make direct changes to the file (e.g. for removing the standard headers listed above).

This then simplifies the process of updating "vk_mem_alloc.h" locally.