### PR TITLE
Include vulkan.h before #define VMA_VULKAN_VERSION

### DIFF
--- a/include/vk_mem_alloc.h
+++ b/include/vk_mem_alloc.h
@@ -126,6 +126,10 @@ for user-defined purpose without allocating any real GPU memory.
 extern "C" {
 #endif
 
+#ifndef VULKAN_H_
+    #include <vulkan/vulkan.h>
+#endif
+
 // Define this macro to declare maximum supported Vulkan version in format AAABBBCCC,
 // where AAA = major, BBB = minor, CCC = patch.
 // If you want to use version > 1.0, it still needs to be enabled via VmaAllocatorCreateInfo::vulkanApiVersion.
@@ -169,10 +173,6 @@ extern "C" {
         extern PFN_vkGetPhysicalDeviceMemoryProperties2 vkGetPhysicalDeviceMemoryProperties2;
     #endif // #if VMA_VULKAN_VERSION >= 1001000
 #endif // #if defined(__ANDROID__) && VMA_STATIC_VULKAN_FUNCTIONS && VK_NO_PROTOTYPES
-
-#ifndef VULKAN_H_
-    #include <vulkan/vulkan.h>
-#endif
 
 #if !defined(VK_VERSION_1_2)
     // This one is tricky. Vulkan specification defines this code as available since


### PR DESCRIPTION
Hi, upon updating my local fork my compilation started hitting the following assert:

https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/blob/4d65f7e113480be158f85e6f924b3d775e215a2b/include/vk_mem_alloc.h#L14582-L14587

This happens because in commit https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/commit/5c710e86a0ce0664bbc2374c39b956b9928b2f29 the definition of `VMA_VULKAN_VERSION` was moved before the include of `<vulkan/vulkan.h>`. So, instead of `1002000` it is now being set to `1000000` (on the `#else` branch), since I'm not including vulkan.h myself in the `.cpp` file where I define `VMA_IMPLEMENTATION`.

https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/blob/4d65f7e113480be158f85e6f924b3d775e215a2b/include/vk_mem_alloc.h#L132-L142

I have opened this PR because I didn't see a particular reason for the order switch in commit https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/commit/5c710e86a0ce0664bbc2374c39b956b9928b2f29, but please let me know if this is something I should correct on my usage of the library (e.g. by defining `VMA_VULKAN_VERSION` myself).