### PR TITLE
Fix VmaSmallVector::push_back

### DIFF
--- a/include/vk_mem_alloc.h
+++ b/include/vk_mem_alloc.h
@@ -4301,8 +4301,9 @@ VmaSmallVector<T, AllocatorT, N>::VmaSmallVector(size_t count, const AllocatorT&
 template<typename T, typename AllocatorT, size_t N>
 void VmaSmallVector<T, AllocatorT, N>::push_back(const T& src)
 {
-    resize(m_Count + 1);
-    data()[m_Count] = src;
+    const size_t newIndex = size();
+    resize(newIndex + 1);
+    data()[newIndex] = src;
 }
 
 template<typename T, typename AllocatorT, size_t N>


### PR DESCRIPTION
`push_back ` on an empty `VmaSmallVector` skipped the first element