### PR TITLE
Fixed two issues with the new defragmenter

### DIFF
--- a/include/vk_mem_alloc.h
+++ b/include/vk_mem_alloc.h
@@ -10909,6 +10909,7 @@ public:
     size_t GetBlockCount() const { return m_Blocks.size(); }
     // To be used only while the m_Mutex is locked. Used during defragmentation.
     VmaDeviceMemoryBlock* GetBlock(size_t index) const { return m_Blocks[index]; }
+    VMA_RW_MUTEX &GetMutex() { return m_Mutex; }
 
     VkResult CreateMinBlocks();
     void AddStatistics(VmaStatistics& inoutStats);
@@ -13064,6 +13065,8 @@ VkResult VmaDefragmentationContext_T::DefragmentPassBegin(VmaDefragmentationPass
 {
     if (m_PoolBlockVector != VMA_NULL)
     {
+        VmaMutexLockWrite lock(m_PoolBlockVector->GetMutex(), m_PoolBlockVector->GetAllocator()->m_UseMutex);
+
         if (m_PoolBlockVector->GetBlockCount() > 1)
             ComputeDefragmentation(*m_PoolBlockVector, 0);
         else if (m_PoolBlockVector->GetBlockCount() == 1)
@@ -13075,6 +13078,8 @@ VkResult VmaDefragmentationContext_T::DefragmentPassBegin(VmaDefragmentationPass
         {
             if (m_pBlockVectors[i] != VMA_NULL)
             {
+                VmaMutexLockWrite lock(m_pBlockVectors[i]->GetMutex(), m_pBlockVectors[i]->GetAllocator()->m_UseMutex);
+
                 if (m_pBlockVectors[i]->GetBlockCount() > 1)
                 {
                     if (ComputeDefragmentation(*m_pBlockVectors[i], i))

--- a/include/vk_mem_alloc.h
+++ b/include/vk_mem_alloc.h
@@ -13276,7 +13276,7 @@ VkResult VmaDefragmentationContext_T::DefragmentPassEnd(VmaDefragmentationPassMo
             for (const FragmentedBlock& block : immovableBlocks)
             {
                 VmaBlockVector* vector = m_pBlockVectors[block.data];
-                for (size_t i = m_ImmovableBlockCount; vector->GetBlockCount(); ++i)
+                for (size_t i = m_ImmovableBlockCount; i < vector->GetBlockCount(); ++i)
                 {
                     if (vector->GetBlock(i) == block.block)
                     {


### PR DESCRIPTION
These are the two actual bugs I have so far run into when trying the new defragmentation API. The first commit fixes a bug that makes the defragmenter unusable if not set to extensive because the loop never terminates (unless you count segfaults). The second is a bit more insidious: I _think_ this is the right place to put the lock, based on the rest of the code, but it is possible that this leads to recursive locking which is a-okay on Windows but not with Linux/Mac pthreads. As best as I can tell this should work, but you probably want to double check that as well.