### PR TITLE
Change: Use std::popcount for VMA_COUNT_BITS_SET in C++20

### DIFF
--- a/include/vk_mem_alloc.h
+++ b/include/vk_mem_alloc.h
@@ -2766,8 +2766,13 @@ static void vma_aligned_free(void* VMA_NULLABLE ptr)
 #endif
 
 #ifndef VMA_COUNT_BITS_SET
-    // Returns number of bits set to 1 in (v)
-    #define VMA_COUNT_BITS_SET(v) VmaCountBitsSet(v)
+    #if __cplusplus >= 202002L // C++20
+        #include <bit>
+        #define VMA_COUNT_BITS_SET(v) std::popcount(v);
+    #else
+        // Returns number of bits set to 1 in (v)
+        #define VMA_COUNT_BITS_SET(v) VmaCountBitsSet(v)
+    #endif
 #endif
 
 #ifndef VMA_BITSCAN_LSB


### PR DESCRIPTION
`VMA_COUNT_BITS_SET` is not optimized anymore by default and I don't think the user should themselves provide a optimization manually, especially when this isn't noted in the changelog (or in the docs?) and the stdlib provides a simple to use implementation.

I think it's appropriate to automatically use [`std::popcount`](https://en.cppreference.com/w/cpp/numeric/popcount) if C++20 is available, as it will include its own optimized implementation from the compiler, which will probably be more optimized than `VmaCountBitsSet`. Additionally, if the project is built with AVX or SSE4 flags enabled, the stdlib automatically uses `__popcnt()` or `__builtin_popcount()` (or at least I observed this with MSVC).
And I think any built-in optimization is welcome.

Also, should this change be reflected in the documentation for `VmaCountBitsSet`?
https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/blob/42be483bd5c6605e789e011aac684e0b95d05359/include/vk_mem_alloc.h#L3166-L3176