### PR TITLE
Remove unused VmaAlgorithmToStr function

### DIFF
--- a/include/vk_mem_alloc.h
+++ b/include/vk_mem_alloc.h
@@ -3377,22 +3377,6 @@ static inline bool VmaStrIsEmpty(const char* pStr)
     return pStr == VMA_NULL || *pStr == '\0';
 }
 
-#if VMA_STATS_STRING_ENABLED
-static const char* VmaAlgorithmToStr(uint32_t algorithm)
-{
-    switch (algorithm)
-    {
-    case VMA_POOL_CREATE_LINEAR_ALGORITHM_BIT:
-        return "Linear";
-    case 0:
-        return "TLSF";
-    default:
-        VMA_ASSERT(0);
-        return "";
-    }
-}
-#endif // VMA_STATS_STRING_ENABLED
-
 #ifndef VMA_SORT
 template<typename Iterator, typename Compare>
 Iterator VmaQuickSortPartition(Iterator beg, Iterator end, Compare cmp)


### PR DESCRIPTION
After commit https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/commit/3c6470cf45816999f906c2dec18ec15a57652000, the `VmaAlgorithmToStr` function is no longer used (which was previously called in `VmaBlockVector::PrintDetailedMap`).

Removing it fixes the following MSVC compier warning: `vk_mem_alloc.h(3381,20): warning C4505: 'VmaAlgorithmToStr': unreferenced function with internal linkage has been removed`.