### PR TITLE
[cmake] Updated installation process to use modern CMake targets

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,7 +24,9 @@ set_target_properties(
     CXX_STANDARD_REQUIRED ON
 )
 
-target_include_directories(VulkanMemoryAllocator PUBLIC "${PROJECT_SOURCE_DIR}/include")
+target_include_directories(VulkanMemoryAllocator PUBLIC 
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+)
 
 # Only link to Vulkan if static linking is used
 if(${VMA_STATIC_VULKAN_FUNCTIONS})
@@ -44,8 +46,7 @@ target_compile_definitions(
     VMA_RECORDING_ENABLED=$<BOOL:${VMA_RECORDING_ENABLED}>
 )
 
-install(TARGETS VulkanMemoryAllocator DESTINATION "lib")
-install(FILES "${PROJECT_SOURCE_DIR}/include/vk_mem_alloc.h" DESTINATION "include")
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/install_target.cmake)
 
 if(VMA_BUILD_SAMPLE)
     if(WIN32)

--- a/src/cmake/Config.cmake.in
+++ b/src/cmake/Config.cmake.in
@@ -1,0 +1,10 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+find_package(Vulkan REQUIRED)
+
+include("${CMAKE_CURRENT_LIST_DIR}/VulkanMemoryAllocatorTargets.cmake")
+check_required_components("@PROJECT_NAME@")
+
+

--- a/src/cmake/install_target.cmake
+++ b/src/cmake/install_target.cmake
@@ -1,0 +1,32 @@
+include(GNUInstallDirs)
+target_include_directories(VulkanMemoryAllocator PUBLIC 
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDE_DIRS}>
+)
+install(TARGETS VulkanMemoryAllocator
+        EXPORT  VulkanMemoryAllocatorTargets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+# install(FILES "${PROJECT_SOURCE_DIR}/include/vk_mem_alloc.h" DESTINATION "include")
+install(FILES "${PROJECT_SOURCE_DIR}/include/vk_mem_alloc.h"
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+install(EXPORT VulkanMemoryAllocatorTargets
+        FILE VulkanMemoryAllocatorTargets.cmake
+        NAMESPACE VulkanMemoryAllocator::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/VulkanMemoryAllocator
+)
+include(CMakePackageConfigHelpers)
+configure_package_config_file(${CMAKE_CURRENT_LIST_DIR}/Config.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/VulkanMemoryAllocatorConfig.cmake"
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/VulkanMemoryAllocator
+)
+install(FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/VulkanMemoryAllocatorConfig.cmake"
+         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/VulkanMemoryAllocator
+)
+
+
+


### PR DESCRIPTION
This is a slight modification of the installation process using modern CMake targets.

Modifications follow CMake recommendations : https://cmake.org/cmake/help/latest/guide/importing-exporting/index.html

This allows to easily integrate VulkanMemoryAllocator in other CMake-based projects (looking as follow)

`find_package(VulkanMemoryAllocator REQUIRED)
target_link_libraries(yourtarget PUBLIC VulkanMemoryAllocator::VulkanMemoryAllocator)
`