### PR TITLE
Fix windows.h not found when cross compiling on Linux

### DIFF
--- a/src/VmaUsage.h
+++ b/src/VmaUsage.h
@@ -33,7 +33,7 @@
     #define WIN32_LEAN_AND_MEAN
 #endif
 
-#include <Windows.h>
+#include <windows.h>
 #if !defined(VK_USE_PLATFORM_WIN32_KHR)
     #define VK_USE_PLATFORM_WIN32_KHR
 #endif // #if !defined(VK_USE_PLATFORM_WIN32_KHR)


### PR DESCRIPTION
The header provided by mingw-w64 on Linux is called windows.h.