### PR TITLE
Fix atomic type used in AtomicTransactionalIncrement

### DIFF
--- a/include/vk_mem_alloc.h
+++ b/include/vk_mem_alloc.h
@@ -4006,6 +4006,8 @@ template<typename AtomicT>
 struct AtomicTransactionalIncrement
 {
 public:
+    using T = decltype(AtomicT().load());
+
     ~AtomicTransactionalIncrement()
     {
         if(m_Atomic)
@@ -4013,7 +4015,7 @@ public:
     }
 
     void Commit() { m_Atomic = nullptr; }
-    typename AtomicT::value_type Increment(AtomicT* atomic)
+    T Increment(AtomicT* atomic)
     {
         m_Atomic = atomic;
         return m_Atomic->fetch_add(1);

--- a/include/vk_mem_alloc.h
+++ b/include/vk_mem_alloc.h
@@ -4002,12 +4002,10 @@ private:
 
 #ifndef _VMA_ATOMIC_TRANSACTIONAL_INCREMENT
 // An object that increments given atomic but decrements it back in the destructor unless Commit() is called.
-template<typename T>
+template<typename AtomicT>
 struct AtomicTransactionalIncrement
 {
 public:
-    typedef std::atomic<T> AtomicT;
-
     ~AtomicTransactionalIncrement()
     {
         if(m_Atomic)
@@ -4015,7 +4013,7 @@ public:
     }
 
     void Commit() { m_Atomic = nullptr; }
-    T Increment(AtomicT* atomic)
+    typename AtomicT::value_type Increment(AtomicT* atomic)
     {
         m_Atomic = atomic;
         return m_Atomic->fetch_add(1);
@@ -15374,7 +15372,7 @@ VkResult VmaAllocator_T::CheckCorruption(uint32_t memoryTypeBits)
 
 VkResult VmaAllocator_T::AllocateVulkanMemory(const VkMemoryAllocateInfo* pAllocateInfo, VkDeviceMemory* pMemory)
 {
-    AtomicTransactionalIncrement<uint32_t> deviceMemoryCountIncrement;
+    AtomicTransactionalIncrement<VMA_ATOMIC_UINT32> deviceMemoryCountIncrement;
     const uint64_t prevDeviceMemoryCount = deviceMemoryCountIncrement.Increment(&m_DeviceMemoryCount);
 #if VMA_DEBUG_DONT_EXCEED_MAX_MEMORY_ALLOCATION_COUNT
     if(prevDeviceMemoryCount >= m_PhysicalDeviceProperties.limits.maxMemoryAllocationCount)


### PR DESCRIPTION
This effectively reverts some of the changes from commit 4dfa169ffc65583cd35bdb7ec13057cde8897c66, pertaining to the `AtomicTransactionalIncrement` class. The problem with them is that they broke compilation when a custom atomic type is defined with `VMA_ATOMIC_UINT32`.

In `VmaAllocator_T::AllocateVulkanMemory()` a call to `AtomicTransactionalIncrement::Increment()` is given as argument a reference to the `m_DeviceMemoryCount`. But the latter will be of the user-defined `VMA_ATOMIC_UINT32` type, while the method expects to be passed a value of the `std::atomic` type.

Reverting those changes has fixed the compilation error with custom atomic types defined.