### PR TITLE
Add GitHub actions to address GNU/Clang warnings

### DIFF
--- a/.github/workflows/vma.yml
+++ b/.github/workflows/vma.yml
@@ -23,6 +23,6 @@ jobs:
           vulkan-components: Vulkan-Headers, Vulkan-Loader
           vulkan-use-cache: true
       - name: Configure VMA
-        run: cmake -S . -B build -G "Ninja" -D CMAKE_BUILD_TYPE=${{matrix.config}}
+        run: cmake -S . -B build -G "Ninja" -D CMAKE_BUILD_TYPE=${{matrix.config}} -D VMA_BUILD_WERROR=ON
       - name: Build VMA
         run: cmake --build build

--- a/.github/workflows/vma.yml
+++ b/.github/workflows/vma.yml
@@ -1,0 +1,28 @@
+name: VMA
+
+on:
+    push:
+    pull_request:
+        branches:
+            - master
+
+jobs:
+  ubuntu-cmake-install:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+          config: [ Debug, Release ]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: lukka/get-cmake@latest
+      # https://github.com/humbletim/setup-vulkan-sdk
+      - name: Prepare Vulkan SDK
+        uses: humbletim/setup-vulkan-sdk@v1.2.0
+        with:
+          vulkan-query-version: 1.3.204.0
+          vulkan-components: Vulkan-Headers, Vulkan-Loader
+          vulkan-use-cache: true
+      - name: Configure VMA
+        run: cmake -S . -B build -G "Ninja" -D CMAKE_BUILD_TYPE=${{matrix.config}}
+      - name: Build VMA
+        run: cmake --build build

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /build/*
 !/bin/VmaSample_Release_vs2019.exe
 !/bin/Shader*.spv
+.vscode/

--- a/include/vk_mem_alloc.h
+++ b/include/vk_mem_alloc.h
@@ -13781,6 +13781,7 @@ bool VmaDefragmentationContext_T::ComputeDefragmentation_Extensive(VmaBlockVecto
             vectorState.operation = StateExtensive::Operation::MoveBuffers;
             bufferPresent = false;
             otherPresent = false;
+            break;
         }
         else
             break;
@@ -13805,6 +13806,7 @@ bool VmaDefragmentationContext_T::ComputeDefragmentation_Extensive(VmaBlockVecto
             // No more buffers to move, check all others
             vectorState.operation = StateExtensive::Operation::MoveAll;
             otherPresent = false;
+            break;
         }
         else
             break;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,7 +23,6 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "(GNU|Clang)")
         -Wno-unused-parameter
         -Wno-unused-variable
         -Wno-missing-field-initializers
-        -Wno-implicit-fallthrough
     )
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,25 @@ add_library(VulkanMemoryAllocator
     ${PROJECT_SOURCE_DIR}/include/vk_mem_alloc.h
 )
 
+option(VMA_BUILD_WERROR "Treat compiler warnings as errors")
+if (VMA_BUILD_WERROR)
+    target_compile_options(VulkanMemoryAllocator PRIVATE
+        "$<IF:$<CXX_COMPILER_ID:MSVC>,/WX,-Werror>"
+    )
+endif()
+
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "(GNU|Clang)")
+    target_compile_options(VulkanMemoryAllocator PRIVATE
+        -Wpedantic
+        -Wall
+        -Wextra
+        -Wno-unused-parameter
+        -Wno-unused-variable
+        -Wno-missing-field-initializers
+        -Wno-implicit-fallthrough
+    )
+endif()
+
 if (MSVC)
     # Provides MSVC users nicer debugging support
     target_sources(VulkanMemoryAllocator PRIVATE ${CMAKE_CURRENT_LIST_DIR}/vk_mem_alloc.natvis)


### PR DESCRIPTION
The intent here is to address warnings coming from `include/vk_mem_alloc.h` and make sure it stays fixed by having it as part of CI.

NOTE: By default VMA_BUILD_ERROR is OFF to not cause package managers any trouble.

Split up into atomic commits to highlight fixing the compiler warnings.