### PR TITLE
Fixes uninitialized vkGetPhysicalDeviceMemoryProperties2KHR

### DIFF
--- a/include/vk_mem_alloc.h
+++ b/include/vk_mem_alloc.h
@@ -14257,7 +14257,7 @@ void VmaAllocator_T::ImportVulkanFunctions_Custom(const VmaVulkanFunctions* pVul
     VMA_COPY_IF_NOT_NULL(vkBindImageMemory2KHR);
 #endif
 
-#if VMA_MEMORY_BUDGET
+#if VMA_MEMORY_BUDGET || VMA_VULKAN_VERSION >= 1001000
     VMA_COPY_IF_NOT_NULL(vkGetPhysicalDeviceMemoryProperties2KHR);
 #endif
 


### PR DESCRIPTION
I caught `VMA_ASSERT(m_VulkanFunctions.vkGetPhysicalDeviceMemoryProperties2KHR != VMA_NULL);` in `ValidateVulkanFunctions` when I was switching VMA to 1.1 for [0 A.D.](https://play0ad.com/) (we use manually provided Vulkan  functions via `VmaVulkanFunctions`).