### PR TITLE
Change __alignof to alignof

### DIFF
--- a/include/vk_mem_alloc.h
+++ b/include/vk_mem_alloc.h
@@ -2806,7 +2806,7 @@ static void vma_aligned_free(void* VMA_NULLABLE ptr)
 #endif
 
 #ifndef VMA_ALIGN_OF
-   #define VMA_ALIGN_OF(type)       (__alignof(type))
+   #define VMA_ALIGN_OF(type)       (alignof(type))
 #endif
 
 #ifndef VMA_SYSTEM_ALIGNED_MALLOC


### PR DESCRIPTION
Whereas __alignof is a non-standard compiler extension that seems to come from Microsoft and is supported (yet undocumented) by Clang and GCC, alignof is a standard language feature in C++11. Clang and GCC both document __alignof__ as a compiler extension, but this isn't supported by Microsoft.

This fixes builds on compilers that don't support __alignof.