### PR TITLE
Add missing cstdio include

### DIFF
--- a/include/vk_mem_alloc.h
+++ b/include/vk_mem_alloc.h
@@ -2602,6 +2602,7 @@ VMA_CALL_PRE void VMA_CALL_POST vmaFreeStatsString(
 #undef VMA_IMPLEMENTATION
 
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <utility>


### PR DESCRIPTION
I noticed this issue when compiling on GCC 13.0.1. GCC complains because "snprintf" is defined by cstdio, but it's not included.