### PR TITLE
Missing cstdio

### DIFF
--- a/include/vk_mem_alloc.h
+++ b/include/vk_mem_alloc.h
@@ -2687,6 +2687,7 @@ remove them if not needed.
     #include <cassert> // for assert
     #include <algorithm> // for min, max
     #include <mutex>
+    #include <cstdio>
 #else
     #include VMA_CONFIGURATION_USER_INCLUDES_H
 #endif


### PR DESCRIPTION
Under Fedora 38 g++ (GCC) 13.0.1 I was getting:

vk_mem_alloc.h:2839:5: error: ‘snprintf’ was not declared in this scope
 2839 |     snprintf(outStr, strLen, "%u", static_cast<unsigned int>(num));


P.S. Masz już bilet na uroczysko Adam ? :)