### PR TITLE
cmake: correctly use find_dependency

### DIFF
--- a/src/cmake/Config.cmake.in
+++ b/src/cmake/Config.cmake.in
@@ -2,7 +2,11 @@
 
 include(CMakeFindDependencyMacro)
 
-find_package(Vulkan REQUIRED)
+if(@VMA_STATIC_VULKAN_FUNCTIONS@)
+    find_dependency(Vulkan)
+else()
+    find_dependency(VulkanHeaders)
+endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/VulkanMemoryAllocatorTargets.cmake")
 check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
`find_package(VulkanMemoryAllocator)` (without `REQUIRED`) should not fail if `Vulkan` is not found.