### PR TITLE
cmake: always add vulkan headers dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,14 +2,6 @@ cmake_minimum_required(VERSION 3.9)
 
 project(VulkanMemoryAllocator LANGUAGES CXX)
 
-# https://cmake.org/cmake/help/latest/variable/PROJECT_IS_TOP_LEVEL.html
-string(COMPARE EQUAL ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR} PROJECT_IS_TOP_LEVEL)
-
-if(PROJECT_IS_TOP_LEVEL)
-    find_package(Vulkan REQUIRED)
-    include_directories(${Vulkan_INCLUDE_DIR})
-endif()
-
 # VulkanMemoryAllocator contains an sample application which is not built by default
 option(VMA_BUILD_SAMPLE "Build VulkanMemoryAllocator sample application" OFF)
 option(VMA_BUILD_SAMPLE_SHADERS "Build VulkanMemoryAllocator sample application's shaders" OFF)
@@ -30,6 +22,12 @@ message(STATUS "VMA_DEBUG_ALWAYS_DEDICATED_MEMORY = ${VMA_DEBUG_ALWAYS_DEDICATED
 message(STATUS "VMA_DEBUG_INITIALIZE_ALLOCATIONS = ${VMA_DEBUG_INITIALIZE_ALLOCATIONS}")
 message(STATUS "VMA_DEBUG_GLOBAL_MUTEX = ${VMA_DEBUG_GLOBAL_MUTEX}")
 message(STATUS "VMA_DEBUG_DONT_EXCEED_MAX_MEMORY_ALLOCATION_COUNT = ${VMA_DEBUG_DONT_EXCEED_MAX_MEMORY_ALLOCATION_COUNT}")
+
+if(VMA_STATIC_VULKAN_FUNCTIONS OR VMA_BUILD_SAMPLE)
+    find_package(Vulkan REQUIRED)
+else()
+    find_package(VulkanHeaders REQUIRED)
+endif()
 
 if(VMA_BUILD_SAMPLE)
     set(VMA_BUILD_SAMPLE_SHADERS ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,9 +26,11 @@ target_include_directories(VulkanMemoryAllocator PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
 )
 
-# Only link to Vulkan if static linking is used
-if(${VMA_STATIC_VULKAN_FUNCTIONS})
+# Only link to Vulkan library if static linking is used, but always add Vulkan headers directory
+if(VMA_STATIC_VULKAN_FUNCTIONS)
     target_link_libraries(VulkanMemoryAllocator PUBLIC Vulkan::Vulkan)
+else()
+    target_link_libraries(VulkanMemoryAllocator PUBLIC Vulkan::Headers)
 endif()
 
 target_compile_definitions(

--- a/src/cmake/install_target.cmake
+++ b/src/cmake/install_target.cmake
@@ -27,6 +27,7 @@ install(FILES
         "${CMAKE_CURRENT_BINARY_DIR}/VulkanMemoryAllocatorConfig.cmake"
          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/VulkanMemoryAllocator
 )
+add_library(VulkanMemoryAllocator::VulkanMemoryAllocator ALIAS VulkanMemoryAllocator)
 
 
 


### PR DESCRIPTION
Vulkan headers directory is always needed because `vulkan/vulkan.h` is included in `src/VmaUsage.h` and `include/vk_mem_alloc.h`.
And the fix for https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/issues/303 was wrong. If `Vulkan::Headers` is already available when VulkanMemoryAllocator is added as a subdirectory, then `find_package(Vulkan)` in `VulkanMemoryAllocator/CMakeLists.txt` will not be executed.
Example code:
```
add_subdirectory(Vulkan-Headers)
set(VMA_STATIC_VULKAN_FUNCTIONS OFF)
set(VMA_DYNAMIC_VULKAN_FUNCTIONS ON)
add_subdirectory(VulkanMemoryAllocator) # VulkanMemoryAllocator will use the headers from the above directory
```

