### PR TITLE
Fixup include of "vk_mem_alloc.h"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,6 +44,8 @@ else()
     target_link_libraries(VmaSample PUBLIC Vulkan::Headers)
 endif()
 
+target_link_libraries(VmaSample PRIVATE GPUOpen::VulkanMemoryAllocator)
+
 target_compile_definitions(VmaSample PUBLIC
     VMA_STATIC_VULKAN_FUNCTIONS=$<BOOL:${VMA_STATIC_VULKAN_FUNCTIONS}>
     VMA_DYNAMIC_VULKAN_FUNCTIONS=$<BOOL:${VMA_DYNAMIC_VULKAN_FUNCTIONS}>

--- a/src/VmaUsage.h
+++ b/src/VmaUsage.h
@@ -95,7 +95,7 @@ include all public interface declarations. Example:
     #pragma clang diagnostic ignored "-Wnullability-completeness"
 #endif
 
-#include "../include/vk_mem_alloc.h"
+#include "vk_mem_alloc.h"
 
 #ifdef __clang__
     #pragma clang diagnostic pop


### PR DESCRIPTION
No need to include via `../include`

By linking against `GPUOpen::VulkanMemoryAllocator` the proper include directory is added to the project.