### PR TITLE
cmake: install docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ if (PROJECT_IS_TOP_LEVEL)
             COMMENT "Generating API documentation with Doxygen"
             VERBATIM
         )
+        install(DIRECTORY docs/ DESTINATION "${CMAKE_INSTALL_DATADIR}/doc/VulkanMemoryAllocator" PATTERN ".nojekyll" EXCLUDE)
     endif()
 
     option(VMA_BUILD_SAMPLES "Build samples")


### PR DESCRIPTION
The documentation is generated but not installed.
And if only the project name was still `VulkanMemoryAllocator` then
```
install(DIRECTORY docs/ DESTINATION "${CMAKE_INSTALL_DATADIR}/doc/VulkanMemoryAllocator" PATTERN ".nojekyll" EXCLUDE)
```
could have been simply:
```
install(DIRECTORY docs/ TYPE DOC PATTERN ".nojekyll" EXCLUDE)
```
By the way,
```
install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
```
can be simplified to:
```
install(DIRECTORY include/ TYPE INCLUDE)
```