### PR TITLE
Fix sub-allocation check in the wraparound path of the linear allocator

### DIFF
--- a/include/vk_mem_alloc.h
+++ b/include/vk_mem_alloc.h
@@ -9088,7 +9088,7 @@ bool VmaBlockMetadata_Linear::CreateAllocationRequest_LowerAddress(
     // beginning of 1st vector as the end of free space.
     if (m_2ndVectorMode == SECOND_VECTOR_EMPTY || m_2ndVectorMode == SECOND_VECTOR_RING_BUFFER)
     {
-        VMA_ASSERT(!suballocations1st.empty());
+        VMA_ASSERT(suballocations1st.data() != nullptr);
 
         VkDeviceSize resultBaseOffset = 0;
         if (!suballocations2nd.empty())


### PR DESCRIPTION
Was this check correct in the first place? Nothing in this section of code actually relies (in a hard way) on the suballocations being empty. In the case I hit, the `suballocations1st` was allocated (for the capacity of 8) but emtpy, while `suballocations2nd` wasn't allocated.