### PR TITLE
Add VK_API_VERSION definitions for compatibility with older Vulkan headers

### DIFF
--- a/include/vk_mem_alloc.h
+++ b/include/vk_mem_alloc.h
@@ -3247,6 +3247,20 @@ static const uint32_t VMA_ALLOCATION_INTERNAL_STRATEGY_MIN_OFFSET = 0x10000000u;
 static const uint32_t VMA_ALLOCATION_TRY_COUNT = 32;
 static const uint32_t VMA_VENDOR_ID_AMD = 4098;
 
+// VK_API_VERSION definitions for compatibility with older Vulkan headers.
+#ifndef VK_API_VERSION_VARIANT
+#define VK_API_VERSION_VARIANT(version) ((uint32_t)(version) >> 29U)
+#endif
+#ifndef VK_API_VERSION_MAJOR
+#define VK_API_VERSION_MAJOR(version) (((uint32_t)(version) >> 22U) & 0x7FU)
+#endif
+#ifndef VK_API_VERSION_MINOR
+#define VK_API_VERSION_MINOR(version) (((uint32_t)(version) >> 12U) & 0x3FFU)
+#endif
+#ifndef VK_API_VERSION_PATCH
+#define VK_API_VERSION_PATCH(version) ((uint32_t)(version) & 0xFFFU)
+#endif
+
 // This one is tricky. Vulkan specification defines this code as available since
 // Vulkan 1.0, but doesn't actually define it in Vulkan SDK earlier than 1.2.131.
 // See pull request #207.


### PR DESCRIPTION
Older Vulkan SDK headers lack the required definitions for `VK_API_VERSION_VARIANT`, `VK_API_VERSION_MAJOR`, `VK_API_VERSION_MINOR`, and `VK_API_VERSION_PATCH`. This causes compilation errors on some platforms, especially those whose official repositories don't contain the latest versions of the Vulkan SDK. This patch checks for these definitions and defines them if necessary. The definitions are taken directly from the SDK, version 1.3.275.0.