### PR TITLE
Make Vulkan include optional

### DIFF
--- a/include/vk_mem_alloc.h
+++ b/include/vk_mem_alloc.h
@@ -127,7 +127,9 @@ See documentation chapter: \ref statistics.
 extern "C" {
 #endif
 
+#if !defined(VULKAN_H_)
 #include <vulkan/vulkan.h>
+#endif
 
 #if !defined(VMA_VULKAN_VERSION)
     #if defined(VK_VERSION_1_3)


### PR DESCRIPTION
- ```#include <vulkan/vulkan.h>``` adds dependency on include directory being set externally
- Dont include vulkan.h if ```VULKAN_H_``` is already defined (if the Vulkan header is already included)