### PR TITLE
Fix ineffective error code checks.

### DIFF
--- a/include/vk_mem_alloc.h
+++ b/include/vk_mem_alloc.h
@@ -16404,7 +16404,7 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateImage(
         pImageCreateInfo,
         allocator->GetAllocationCallbacks(),
         pImage);
-    if(res >= 0)
+    if(res == VK_SUCCESS)
     {
         VmaSuballocationType suballocType = pImageCreateInfo->tiling == VK_IMAGE_TILING_OPTIMAL ?
             VMA_SUBALLOCATION_TYPE_IMAGE_OPTIMAL :
@@ -16429,14 +16429,14 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateImage(
             1, // allocationCount
             pAllocation);
 
-        if(res >= 0)
+        if(res == VK_SUCCESS)
         {
             // 3. Bind image with memory.
             if((pAllocationCreateInfo->flags & VMA_ALLOCATION_CREATE_DONT_BIND_BIT) == 0)
             {
                 res = allocator->BindImageMemory(*pAllocation, 0, *pImage, VMA_NULL);
             }
-            if(res >= 0)
+            if(res == VK_SUCCESS)
             {
                 // All steps succeeded.
                 #if VMA_STATS_STRING_ENABLED


### PR DESCRIPTION
I believe that the error code checking in `vmaCreateImage` is wrong, possibly causing null pointer dereferencing issues, if allocation fails. The checks in this method test the result value against `>= 0`, which should always evaluate to `true`, as `VK_SUCCESS` is defined as `0` and all errors are integers greater than that. This function is the only function that tests results this way.

This PR replaces the checks by explicitly testing against `VK_SUCCESS`, which I believe is the intended behavior.

For context, I've encountered this issue, as clang-tidy complained about a possible null pointer deref here: 

https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/blob/05973d8aeb1a4d12f59aadfb86d20decadba82d1/include/vk_mem_alloc.h#L16161-L16188

... which from my understanding can happen if the earlier call to `allocator->AllocateMemory` fails. In this case, `pAllocation` will be freed and explicitly set to `0` (for example [here](https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/blob/05973d8aeb1a4d12f59aadfb86d20decadba82d1/include/vk_mem_alloc.h#L13722)). Depending on the exact configuration and provided flags, the code may then attempt to dereference the null `pAllocation` in one of the three function calls below line 16163.