### PR TITLE
Include vulkan_win32.h only for Windows

### DIFF
--- a/src/VmaUsage.h
+++ b/src/VmaUsage.h
@@ -97,7 +97,10 @@ include all public interface declarations. Example:
 #endif
 
 #include <vulkan/vulkan.h>
+
+#ifdef _WIN32
 #include <vulkan/vulkan_win32.h>
+#endif  // #ifdef _WIN32
 
 #include "vk_mem_alloc.h"
 


### PR DESCRIPTION
Closes https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/issues/456

Does this fix it? @FuXiii