### PR TITLE
Enable all gcc and clang warnings for testing the CI

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -57,6 +57,28 @@ jobs:
       run: |
         cmake -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
           -DVMA_BUILD_SAMPLES=YES \
+          -DCMAKE_CXX_FLAGS="-Wall
+                              -Wextra
+                              -Wpedantic
+                              -Wconversion
+                              -Wsign-conversion
+                              -Wshadow
+                              -Wnull-dereference
+                              -Wdouble-promotion
+                              -Wformat=2
+                              -Wimplicit-fallthrough
+                              -Wundef
+                              -Wcast-align
+                              -Woverloaded-virtual
+                              -Wnon-virtual-dtor
+                              -Wstrict-overflow=5
+                              -Wuseless-cast
+                              -Wduplicated-cond
+                              -Wduplicated-branches
+                              -Wlogical-op
+                              -Wredundant-decls
+                              -Wstrict-null-sentinel
+                              -Wold-style-cast"
           $GITHUB_WORKSPACE
 
     - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,34 +34,6 @@ if (CMAKE_VERSION VERSION_LESS "3.21")
     string(COMPARE EQUAL ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR} PROJECT_IS_TOP_LEVEL)
 endif()
 
-# Set warning flags for gcc and clang
-if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}
-                            -Wall
-                            -Wextra
-                            -Wpedantic
-                            -Wconversion
-                            -Wsign-conversion
-                            -Wshadow
-                            -Wnull-dereference
-                            -Wdouble-promotion
-                            -Wformat=2
-                            -Wimplicit-fallthrough
-                            -Wundef
-                            -Wcast-align
-                            -Woverloaded-virtual
-                            -Wnon-virtual-dtor
-                            -Wstrict-overflow=5
-                            -Wuseless-cast
-                            -Wduplicated-cond
-                            -Wduplicated-branches
-                            -Wlogical-op
-                            -Wredundant-decls
-                            -Wstrict-null-sentinel
-                            -Wold-style-cast")
-    message(STATUS "CMAKE_CXX_FLAGS: " ${CMAKE_CXX_FLAGS})
-endif()
-
 option(VMA_ENABLE_INSTALL "Install VulkanMemoryAllocator" ${PROJECT_IS_TOP_LEVEL})
 if (VMA_ENABLE_INSTALL)
     include(GNUInstallDirs)


### PR DESCRIPTION
* Some of these warnings are probably way too overpowered, but we can remove them as necessary.
* None of these warnings should cause the build to fail (specifying warnings as errors `-Werror` would do this)