### PR TITLE
Revert "Enable all gcc and clang warnings for testing the CI"

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -57,28 +57,6 @@ jobs:
       run: |
         cmake -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
           -DVMA_BUILD_SAMPLES=YES \
-          -DCMAKE_CXX_FLAGS="-Wall
-                              -Wextra
-                              -Wpedantic
-                              -Wconversion
-                              -Wsign-conversion
-                              -Wshadow
-                              -Wnull-dereference
-                              -Wdouble-promotion
-                              -Wformat=2
-                              -Wimplicit-fallthrough
-                              -Wundef
-                              -Wcast-align
-                              -Woverloaded-virtual
-                              -Wnon-virtual-dtor
-                              -Wstrict-overflow=5
-                              -Wuseless-cast
-                              -Wduplicated-cond
-                              -Wduplicated-branches
-                              -Wlogical-op
-                              -Wredundant-decls
-                              -Wstrict-null-sentinel
-                              -Wold-style-cast"
           $GITHUB_WORKSPACE
 
     - name: Build


### PR DESCRIPTION
Reverts GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator#478

Build failed!