### PR TITLE
Add more warnings to ignore list of clang-tidy for static code analysis

### DIFF
--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -42,4 +42,16 @@ jobs:
 
     - name: Run Clang-Tidy
       run: |
-        find . -name '*.cpp' | xargs clang-tidy-15 -checks='*, -modernize-use-trailing-return-type, -cppcoreguidelines-macro-usage, -modernize-use-auto, -modernize-use-using' -header-filter='.*vk_mem_alloc\.h' -p build || true
+        find . -name '*.cpp' | xargs clang-tidy-15 -checks='*, \
+                                                    -modernize-use-trailing-return-type, \
+                                                    -cppcoreguidelines-macro-usage, \
+                                                    -modernize-use-auto, \
+                                                    -modernize-use-using \
+                                                    -modernize-use-nodiscard \
+                                                    -altera-unroll-loops \
+                                                    -misc-definitions-in-headers \
+                                                    -cppcoreguidelines-pro-bounds-pointer-arithmetic \
+                                                    -readability-function-cognitive-complexity \
+                                                    -llvmlibc-restrict-system-libc-headers \
+                                                    -cppcoreguidelines-pro-type-union-access' \
+                                                    -header-filter='.*vk_mem_alloc\.h' -p build || true


### PR DESCRIPTION
See https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/issues/484

Please check if this runs correctly

(Sometimes I can't run the CI in my fork, I don't know why but it seems to be an issue with GitHub).