### PR TITLE
Use a cache instead of downloading Vulkan SDK with every CI run

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -1,4 +1,4 @@
-name: Build code on Linux
+name: Build code
 
 on:
   push:
@@ -23,26 +23,33 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Set Vulkan SDK Version
+      id: set-version
+      run: echo "VULKAN_SDK_VERSION=1.3.283.0" >> $GITHUB_ENV
+
     - name: Create Build Environment
       run: |
         sudo apt update
         ${{matrix.install}}
         cmake -E make_directory ${{runner.workspace}}/build
 
-    - name: Prepare Vulkan SDK
-      shell: bash
+    - name: Check for Vulkan SDK Cache
+      id: cache-vulkan
+      uses: actions/cache@v4
+      with:
+        path: vulkan_sdk
+        key: vulkan-sdk-${{env.VULKAN_SDK_VERSION}}
+
+    - name: Download Vulkan SDK
+      if: steps.cache-vulkan.outputs.cache-hit != 'true'
       run: |
-        curl -LS -o vulkansdk.tar.xz https://sdk.lunarg.com/sdk/download/1.4.309.0/linux/vulkansdk-linux-x86_64-1.4.309.0.tar.xz
+        curl -LS -o vulkansdk.tar.xz https://sdk.lunarg.com/sdk/download/${{env.VULKAN_SDK_VERSION}}/linux/vulkansdk-linux-x86_64-${{env.VULKAN_SDK_VERSION}}.tar.xz
         mkdir -p vulkan_sdk
         tar xf vulkansdk.tar.xz -C vulkan_sdk
-        rm -rf vulkansdk.tar.xz
-        
-        export VULKAN_SDK=$GITHUB_WORKSPACE/vulkan_sdk/1.4.309.0/x86_64
-        export PATH=$VULKAN_SDK/bin:$PATH
-        export LD_LIBRARY_PATH=$VULKAN_SDK/lib:$LD_LIBRARY_PATH
-        export VK_ICD_FILENAMES=$VULKAN_SDK/etc/vulkan/icd.d
-        export VK_LAYER_PATH=$VULKAN_SDK/etc/vulkan/layer.d
 
+    - name: Set environment variables
+      run: |
+        export VULKAN_SDK=$GITHUB_WORKSPACE/vulkan_sdk/${{env.VULKAN_SDK_VERSION}}/x86_64
         echo "VULKAN_SDK=$VULKAN_SDK" >> $GITHUB_ENV
         echo "PATH=$VULKAN_SDK/bin:$PATH" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=$VULKAN_SDK/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV

--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -1,4 +1,4 @@
-name: Static code analysis (clang-tidy)
+name: Static code analysis
 
 on:
   push:
@@ -12,39 +12,38 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    # Cache Vulkan SDK
-    - name: Cache Vulkan SDK
-      id: cache-vulkan
-      uses: actions/cache@v4
-      with:
-        path: vulkan_sdk
-        key: vulkan-sdk-1.4.309.0
+    - name: Set Vulkan SDK Version
+      id: set-version
+      run: echo "VULKAN_SDK_VERSION=1.3.283.0" >> $GITHUB_ENV
 
-    # Install system dependencies
     - name: Install system dependencies
       run: |
         sudo apt update
         sudo apt install -y clang-15 clang-tidy-15 cmake parallel libc++-15-dev libc++abi-15-dev
 
-    # Download Vulkan SDK only if not cached
+    - name: Check for Vulkan SDK Cache
+      id: cache-vulkan
+      uses: actions/cache@v4
+      with:
+        path: vulkan_sdk
+        key: vulkan-sdk-${{env.VULKAN_SDK_VERSION}}
+
     - name: Download Vulkan SDK
       if: steps.cache-vulkan.outputs.cache-hit != 'true'
       run: |
-        curl -LS -o vulkansdk.tar.xz https://sdk.lunarg.com/sdk/download/1.4.309.0/linux/vulkansdk-linux-x86_64-1.4.309.0.tar.xz
+        curl -LS -o vulkansdk.tar.xz https://sdk.lunarg.com/sdk/download/${{env.VULKAN_SDK_VERSION}}/linux/vulkansdk-linux-x86_64-${{env.VULKAN_SDK_VERSION}}.tar.xz
         mkdir -p vulkan_sdk
         tar xf vulkansdk.tar.xz -C vulkan_sdk
 
-    # Set environment variables for Clang and Vulkan SDK
     - name: Set environment variables
       run: |
         echo "CLANG_TIDY=clang-tidy-15" >> $GITHUB_ENV
-        echo "VULKAN_SDK=${GITHUB_WORKSPACE}/vulkan_sdk/1.4.309.0/x86_64" >> $GITHUB_ENV
-        echo "PATH=${GITHUB_WORKSPACE}/vulkan_sdk/1.4.309.0/x86_64/bin:$PATH" >> $GITHUB_ENV
-        echo "LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/vulkan_sdk/1.4.309.0/x86_64/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-        echo "VK_ICD_FILENAMES=${GITHUB_WORKSPACE}/vulkan_sdk/1.4.309.0/x86_64/etc/vulkan/icd.d" >> $GITHUB_ENV
-        echo "VK_LAYER_PATH=${GITHUB_WORKSPACE}/vulkan_sdk/1.4.309.0/x86_64/etc/vulkan/layer.d" >> $GITHUB_ENV
+        echo "VULKAN_SDK=${GITHUB_WORKSPACE}/vulkan_sdk/${{env.VULKAN_SDK_VERSION}}/x86_64" >> $GITHUB_ENV
+        echo "PATH=${GITHUB_WORKSPACE}/vulkan_sdk/${{env.VULKAN_SDK_VERSION}}/x86_64/bin:$PATH" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/vulkan_sdk/${{env.VULKAN_SDK_VERSION}}/x86_64/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        echo "VK_ICD_FILENAMES=${GITHUB_WORKSPACE}/vulkan_sdk/${{env.VULKAN_SDK_VERSION}}/x86_64/etc/vulkan/icd.d" >> $GITHUB_ENV
+        echo "VK_LAYER_PATH=${GITHUB_WORKSPACE}/vulkan_sdk/${{env.VULKAN_SDK_VERSION}}/x86_64/etc/vulkan/layer.d" >> $GITHUB_ENV
 
-    # Configure the project with CMake
     - name: Configure with CMake
       run: |
         cmake -S . -B build \
@@ -53,7 +52,6 @@ jobs:
           -DCMAKE_C_COMPILER=clang-15 \
           -DVMA_BUILD_SAMPLES=YES
 
-    # List files to analyze
     - name: Check the files found for clang-tidy
       run: |
         find src include \
@@ -61,7 +59,6 @@ jobs:
           -path '*/build/*' -prune -o \
           \( -name '*.cpp' -o -name '*.hpp' \) -print
 
-    # Run clang-tidy in parallel
     - name: Run clang-tidy
       run: |
         find src include \
@@ -71,7 +68,6 @@ jobs:
           parallel -0 clang-tidy -p build {} |
           tee output || true
 
-    # Summarize warnings
     - name: Summarize clang-tidy warnings
       run: |
         grep -hEo '\[[a-z0-9]+-[a-z0-9-]+\]' output \

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -7,7 +7,7 @@ on:
 
 env:
   VMA_VULKAN_VERSION: "1.3.283.0"
-  VMA_VULKAN_SDK_PATH: "$GITHUB_WORKSPACE/../vulkan_sdk/"
+  VMA_VULKAN_SDK_PATH: ${{ github.workspace }}/vulkan_sdk
 
 jobs:
   windows:
@@ -33,14 +33,26 @@ jobs:
           }
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Install Vulkan SDK
+      - name: Check for Vulkan SDK Cache
+        id: cache-vulkan
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.VMA_VULKAN_SDK_PATH }}
+          key: vulkan-sdk-${{ env.VMA_VULKAN_VERSION }}
+
+      - name: Download Vulkan SDK
+        if: steps.cache-vulkan.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
-          curl -LS -o vulkansdk.exe https://sdk.lunarg.com/sdk/download/${{ env.VMA_VULKAN_VERSION }}/windows/VulkanSDK-${{ env.VMA_VULKAN_VERSION }}-Installer.exe
-          7z x vulkansdk.exe -o"${{ env.VMA_VULKAN_SDK_PATH }}"
+          if (-Not (Test-Path ${{ env.VMA_VULKAN_SDK_PATH }})) {
+            Write-Host "Vulkan SDK not found in cache. Downloading..."
+            curl -LS -o vulkansdk.exe https://sdk.lunarg.com/sdk/download/${{ env.VMA_VULKAN_VERSION }}/windows/VulkanSDK-${{ env.VMA_VULKAN_VERSION }}-Installer.exe
+            7z x vulkansdk.exe -o"${{ env.VMA_VULKAN_SDK_PATH }}"
+          } else {
+            Write-Host "Using cached Vulkan SDK"
+          }
 
       - name: Configure CMake
         shell: pwsh


### PR DESCRIPTION
Closes #490 

On the second run, the step of downloading Vulkan SDK should be skipped in build (windows and linux) as well as in clang-tidy.
Here's an example of Windows MSVC debug build:

![grafik](https://github.com/user-attachments/assets/389e2b01-fe7d-412a-9b2d-430c7b936510)