### PR TITLE
Small improvements of tests

### DIFF
--- a/src/Tests.cpp
+++ b/src/Tests.cpp
@@ -6340,9 +6340,6 @@ static void TestAdvancedDataUploading() {
         TEST(stagingBufferAllocInfo.pMappedData != nullptr);
         vmaCopyMemoryToAllocation(g_hAllocator, bufferData.data(), stagingBufferAlloc, 0, bufferData.size());
 
-        result = vmaFlushAllocation(g_hAllocator, uniformBufferAlloc, 0, VK_WHOLE_SIZE);
-        TEST(result == VK_SUCCESS);
-
         BeginSingleTimeCommands();
 
         VkBufferMemoryBarrier bufferMemBarrier = { VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER };

--- a/src/Tests.cpp
+++ b/src/Tests.cpp
@@ -6181,7 +6181,8 @@ static void TestDataUploadingWithStagingBuffer()
     TEST(result == VK_SUCCESS);
 
     TEST(stagingBufferAllocInfo.pMappedData != nullptr);
-    vmaCopyMemoryToAllocation(g_hAllocator, bufferData.data(), stagingBufferAlloc, 0, bufferData.size());
+    result = vmaCopyMemoryToAllocation(g_hAllocator, bufferData.data(), stagingBufferAlloc, 0, bufferData.size());
+    TEST(result == VK_SUCCESS);
 
     BeginSingleTimeCommands();
 
@@ -6251,7 +6252,8 @@ static void TestDataUploadingWithMappedMemory() {
     TEST(memPropFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
 
     TEST(uniformBufferAllocInfo.pMappedData != nullptr);
-    vmaCopyMemoryToAllocation(g_hAllocator, bufferData.data(), uniformBufferAlloc, 0, bufferData.size());
+    result = vmaCopyMemoryToAllocation(g_hAllocator, bufferData.data(), uniformBufferAlloc, 0, bufferData.size());
+    TEST(result == VK_SUCCESS);
 
     BeginSingleTimeCommands();
 
@@ -6303,7 +6305,8 @@ static void TestAdvancedDataUploading() {
     if (memPropFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) {
         // The allocation ended up as mapped memory.
         TEST(uniformBufferAllocInfo.pMappedData != nullptr);
-        vmaCopyMemoryToAllocation(g_hAllocator, bufferData.data(), uniformBufferAlloc, 0, bufferData.size());
+        result = vmaCopyMemoryToAllocation(g_hAllocator, bufferData.data(), uniformBufferAlloc, 0, bufferData.size());
+        TEST(result == VK_SUCCESS);
 
         BeginSingleTimeCommands();
 
@@ -6338,7 +6341,8 @@ static void TestAdvancedDataUploading() {
         TEST(result == VK_SUCCESS);
 
         TEST(stagingBufferAllocInfo.pMappedData != nullptr);
-        vmaCopyMemoryToAllocation(g_hAllocator, bufferData.data(), stagingBufferAlloc, 0, bufferData.size());
+        result = vmaCopyMemoryToAllocation(g_hAllocator, bufferData.data(), stagingBufferAlloc, 0, bufferData.size());
+        TEST(result == VK_SUCCESS);
 
         BeginSingleTimeCommands();
 


### PR DESCRIPTION
`vmaFlushAllocation` is unnecessary here because [vmaCopyMemoryToAllocation](https://gpuopen-librariesandsdks.github.io/VulkanMemoryAllocator/html/group__group__alloc.html#ga11731ec58a3a43a22bb925e0780ef405) does that internally if it's required.
This small mistake made it somehow through when discussing pull request https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/pull/474.
I only found this in this test, the others seem to be correct.