### PR TITLE
Fix some MSVC warnings

### DIFF
--- a/include/vk_mem_alloc.h
+++ b/include/vk_mem_alloc.h
@@ -4600,7 +4600,8 @@ void VmaVector<T, AllocatorT>::resize(size_t newCount)
 
     if (newCapacity != m_Capacity)
     {
-        T* const newArray = newCapacity ? VmaAllocateArray<T>(m_Allocator.m_pCallbacks, newCapacity) : VMA_NULL;
+        VMA_HEAVY_ASSERT(newCapacity != 0);
+        T* const newArray = VmaAllocateArray<T>(m_Allocator.m_pCallbacks, newCapacity);
         const size_t elementsToCopy = VMA_MIN(m_Count, newCount);
         if (elementsToCopy != 0)
         {

--- a/include/vk_mem_alloc.h
+++ b/include/vk_mem_alloc.h
@@ -14048,11 +14048,12 @@ VkResult VmaAllocator_T::CalcAllocationParams(
         return VK_ERROR_FEATURE_NOT_PRESENT;
     }
 
-    if(VMA_DEBUG_ALWAYS_DEDICATED_MEMORY &&
-        (inoutCreateInfo.flags & VMA_ALLOCATION_CREATE_NEVER_ALLOCATE_BIT) != 0)
+#if VMA_DEBUG_ALWAYS_DEDICATED_MEMORY
+    if((inoutCreateInfo.flags & VMA_ALLOCATION_CREATE_NEVER_ALLOCATE_BIT) != 0)
     {
         inoutCreateInfo.flags |= VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT;
     }
+#endif
 
     // Non-auto USAGE values imply HOST_ACCESS flags.
     // And so does VMA_MEMORY_USAGE_UNKNOWN because it is used with custom pools.
@@ -15018,9 +15019,9 @@ void VmaAllocator_T::UpdateVulkanBudget()
 
 void VmaAllocator_T::FillAllocation(VmaAllocation hAllocation, uint8_t pattern)
 {
-    if(VMA_DEBUG_INITIALIZE_ALLOCATIONS &&
-        hAllocation->IsMappingAllowed() &&
-        (m_MemProps.memoryTypes[hAllocation->GetMemoryTypeIndex()].propertyFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) != 0)
+#if VMA_DEBUG_INITIALIZE_ALLOCATIONS
+    if(hAllocation->IsMappingAllowed() &&
+       (m_MemProps.memoryTypes[hAllocation->GetMemoryTypeIndex()].propertyFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) != 0)
     {
         void* pData = VMA_NULL;
         VkResult res = Map(hAllocation, &pData);
@@ -15035,6 +15036,10 @@ void VmaAllocator_T::FillAllocation(VmaAllocation hAllocation, uint8_t pattern)
             VMA_ASSERT(0 && "VMA_DEBUG_INITIALIZE_ALLOCATIONS is enabled, but couldn't map memory to fill allocation.");
         }
     }
+#else
+    (void)hAllocation;
+    (void)pattern;
+#endif
 }
 
 uint32_t VmaAllocator_T::GetGpuDefragmentationMemoryTypeBits()

--- a/include/vk_mem_alloc.h
+++ b/include/vk_mem_alloc.h
@@ -11367,10 +11367,10 @@ bool VmaBlockVector::IsEmpty()
 
 bool VmaBlockVector::IsCorruptionDetectionEnabled() const
 {
-    const uint32_t requiredMemFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
 #if (VMA_DEBUG_DETECT_CORRUPTION == 0) || (VMA_DEBUG_MARGIN <= 0)
     return false;
 #else
+    const uint32_t requiredMemFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     return (m_Algorithm == 0 || m_Algorithm == VMA_POOL_CREATE_LINEAR_ALGORITHM_BIT) &&
            (m_hAllocator->m_MemProps.memoryTypes[m_MemoryTypeIndex].propertyFlags & requiredMemFlags) == requiredMemFlags;
 #endif

--- a/include/vk_mem_alloc.h
+++ b/include/vk_mem_alloc.h
@@ -3818,6 +3818,8 @@ static void VmaWriteMagicValue(void* pData, VkDeviceSize offset)
     }
 #else
     // no-op
+    (void)pData;
+    (void)offset;
 #endif
 }
 
@@ -3833,6 +3835,9 @@ static bool VmaValidateMagicValue(const void* pData, VkDeviceSize offset)
             return false;
         }
     }
+#else
+    (void)pData;
+    (void)offset;
 #endif
     return true;
 }
@@ -6430,7 +6435,7 @@ public:
     bool IsPersistentMap() const { return (m_Flags & FLAG_PERSISTENT_MAP) != 0; }
     bool IsMappingAllowed() const { return (m_Flags & FLAG_MAPPING_ALLOWED) != 0; }
 
-    void SetUserData(VmaAllocator hAllocator, void* pUserData) { m_pUserData = pUserData; }
+    void SetUserData(VmaAllocator hAllocator, void* pUserData) { (void)hAllocator; m_pUserData = pUserData; }
     void SetName(VmaAllocator hAllocator, const char* pName);
     void FreeName(VmaAllocator hAllocator);
     uint8_t SwapBlockAllocation(VmaAllocator hAllocator, VmaAllocation allocation);
@@ -6828,6 +6833,10 @@ VmaBlockMetadata::VmaBlockMetadata(const VkAllocationCallbacks* pAllocationCallb
 
 void VmaBlockMetadata::DebugLogAllocation(VkDeviceSize offset, VkDeviceSize size, void* userData) const
 {
+    // Variables will be unreferenced and generate compiler warnings if `VMA_LEAK_LOG_FORMAT` is not defined
+    (void)offset;
+    (void)size;
+
     if (IsVirtual())
     {
         VMA_LEAK_LOG_FORMAT("UNFREED VIRTUAL ALLOCATION; Offset: %" PRIu64 "; Size: %" PRIu64 "; UserData: %p", offset, size, userData);
@@ -6839,6 +6848,7 @@ void VmaBlockMetadata::DebugLogAllocation(VkDeviceSize offset, VkDeviceSize size
 
         userData = allocation->GetUserData();
         const char* name = allocation->GetName();
+        (void)name;
 
 #if VMA_STATS_STRING_ENABLED
         VMA_LEAK_LOG_FORMAT("UNFREED ALLOCATION; Offset: %" PRIu64 "; Size: %" PRIu64 "; UserData: %p; Name: %s; Type: %s; Usage: %" PRIu64,
@@ -8364,6 +8374,7 @@ VmaAllocHandle VmaBlockMetadata_Linear::GetNextAllocation(VmaAllocHandle prevAll
 {
     // Function only used for defragmentation, which is disabled for this algorithm
     VMA_ASSERT(0);
+    (void)prevAlloc;
     return VK_NULL_HANDLE;
 }
 
@@ -8371,6 +8382,7 @@ VkDeviceSize VmaBlockMetadata_Linear::GetNextFreeRegionSize(VmaAllocHandle alloc
 {
     // Function only used for defragmentation, which is disabled for this algorithm
     VMA_ASSERT(0);
+    (void)alloc;
     return 0;
 }
 
@@ -8562,6 +8574,8 @@ bool VmaBlockMetadata_Linear::CreateAllocationRequest_LowerAddress(
     uint32_t strategy,
     VmaAllocationRequest* pAllocationRequest)
 {
+    (void)strategy;
+
     const VkDeviceSize blockSize = GetSize();
     const VkDeviceSize debugMargin = GetDebugMargin();
     const VkDeviceSize bufferImageGranularity = GetBufferImageGranularity();
@@ -8740,6 +8754,8 @@ bool VmaBlockMetadata_Linear::CreateAllocationRequest_UpperAddress(
     uint32_t strategy,
     VmaAllocationRequest* pAllocationRequest)
 {
+    (void)strategy;
+
     const VkDeviceSize blockSize = GetSize();
     const VkDeviceSize bufferImageGranularity = GetBufferImageGranularity();
     SuballocationVectorType& suballocations1st = AccessSuballocations1st();
@@ -9371,6 +9387,8 @@ void VmaBlockMetadata_TLSF::Alloc(
     VmaSuballocationType type,
     void* userData)
 {
+    (void)type;
+
     VMA_ASSERT(request.type == VmaAllocationRequestType::TLSF);
 
     // Get block and pop it from the free list
@@ -10662,7 +10680,7 @@ VmaDeviceMemoryBlock::VmaDeviceMemoryBlock(VmaAllocator hAllocator)
     m_Id(0),
     m_hMemory(VK_NULL_HANDLE),
     m_MapCount(0),
-    m_pMappedData(VMA_NULL){}
+    m_pMappedData(VMA_NULL){ (void)hAllocator; }
 
 VmaDeviceMemoryBlock::~VmaDeviceMemoryBlock()
 {
@@ -13165,6 +13183,8 @@ VmaAllocator_T::VmaAllocator_T(const VmaAllocatorCreateInfo* pCreateInfo) :
 
 VkResult VmaAllocator_T::Init(const VmaAllocatorCreateInfo* pCreateInfo)
 {
+    (void)pCreateInfo;
+
     VkResult res = VK_SUCCESS;
 
 #if VMA_MEMORY_BUDGET
@@ -16173,6 +16193,8 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaBeginDefragmentationPass(
     VmaDefragmentationContext VMA_NOT_NULL context,
     VmaDefragmentationPassMoveInfo* VMA_NOT_NULL pPassInfo)
 {
+    (void)allocator;
+
     VMA_ASSERT(context && pPassInfo);
 
     VMA_DEBUG_LOG("vmaBeginDefragmentationPass");
@@ -16187,6 +16209,8 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaEndDefragmentationPass(
     VmaDefragmentationContext VMA_NOT_NULL context,
     VmaDefragmentationPassMoveInfo* VMA_NOT_NULL pPassInfo)
 {
+    (void)allocator;
+
     VMA_ASSERT(context && pPassInfo);
 
     VMA_DEBUG_LOG("vmaEndDefragmentationPass");

--- a/include/vk_mem_alloc.h
+++ b/include/vk_mem_alloc.h
@@ -11368,10 +11368,12 @@ bool VmaBlockVector::IsEmpty()
 bool VmaBlockVector::IsCorruptionDetectionEnabled() const
 {
     const uint32_t requiredMemFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-    return (VMA_DEBUG_DETECT_CORRUPTION != 0) &&
-        (VMA_DEBUG_MARGIN > 0) &&
-        (m_Algorithm == 0 || m_Algorithm == VMA_POOL_CREATE_LINEAR_ALGORITHM_BIT) &&
-        (m_hAllocator->m_MemProps.memoryTypes[m_MemoryTypeIndex].propertyFlags & requiredMemFlags) == requiredMemFlags;
+#if (VMA_DEBUG_DETECT_CORRUPTION == 0) || (VMA_DEBUG_MARGIN <= 0)
+    return false;
+#else
+    return (m_Algorithm == 0 || m_Algorithm == VMA_POOL_CREATE_LINEAR_ALGORITHM_BIT) &&
+           (m_hAllocator->m_MemProps.memoryTypes[m_MemoryTypeIndex].propertyFlags & requiredMemFlags) == requiredMemFlags;
+#endif
 }
 
 VkResult VmaBlockVector::Allocate(


### PR DESCRIPTION
Minor changes to reduce the number of compile warnings emitted. I'm using VMA in a unity build with MSVC and fairly strict compile settings in Debug mode. I saw it mentioned before that fixing compile warnings isn't considered important (Understandably), so it's fine to close the PR if the changes are considered against the preferences of the project.

Overview:

- Mark unused variables with (void)var;
- In `VmaVector<T, AllocatorT>::resize` remove ternary branch as it should not be possible for `newCapacity ` to be 0. Apart from removing an unnecessary branch and clearing up intent, it removes a warning about potentially passing NULL as input to `memcpy`, which is undefined behavior.
- Hoist compile time known macros out of runtime expressions

Notes:

- There were 1 or 2 places where marking a variable as unused wasn't perfectly clean, for example if it's just used in a macro such as `VMA_LEAK_LOG_FORMAT` which may not may not expand to an expression. I figured it was still better to include them if warnings about unused variables aren't considered useful anyways, at least it reduces build noise.
- Probably intentional, but `VmaVector<T, AllocatorT>::resize` will allocate a new buffer and copy over the contents even if the new capacity is less than the current. I don't know if there's an easy way to just shrink the allocation in such a case to avoid the overhead of allocating a new buffer and doing a `memcpy`. I didn't look into it for this PR.