### PR TITLE
Added Win32 Import function prototype

### DIFF
--- a/src/Tests.cpp
+++ b/src/Tests.cpp
@@ -380,7 +380,7 @@ VkResult MainTest(Result& outResult, const Config& config)
 
     time_point timeBeg = std::chrono::high_resolution_clock::now();
 
-    std::atomic<size_t> allocationCount = 0;
+    std::atomic<size_t> allocationCount{ 0 };
     VkResult res = VK_SUCCESS;
 
     uint32_t memUsageProbabilitySum =
@@ -545,7 +545,7 @@ VkResult MainTest(Result& outResult, const Config& config)
         }
     };
 
-    std::atomic<uint32_t> numThreadsReachedMaxAllocations = 0;
+    std::atomic<uint32_t> numThreadsReachedMaxAllocations{ 0 };
     HANDLE threadsFinishEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
 
     auto ThreadProc = [&](uint32_t randSeed) -> void


### PR DESCRIPTION
I have added an import function for Win32 Handle and also added `vmaGetMemoryWin32Handle2` that can export handle with supplied handle type. Note that Allocator **must** be created with support for supplied handle type.

Closes #499 