### PR TITLE
CMake: Additional target ALIAS in the VulkanMemoryAllocator namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ project(VMA VERSION 3.3.0 LANGUAGES CXX)
 
 add_library(VulkanMemoryAllocator INTERFACE)
 add_library(GPUOpen::VulkanMemoryAllocator ALIAS VulkanMemoryAllocator)
+add_library(VulkanMemoryAllocator::Headers ALIAS VulkanMemoryAllocator)
 
 target_include_directories(VulkanMemoryAllocator INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 


### PR DESCRIPTION
As per title, this simply adds the new alias `VulkanMemoryAllocator::Headers`.

The goal is to have a sort of parallel to the `Vulkan::Headers`, `Vulkan::Hpp` and `Vulkan::HppModule` targets.
[YaaZ/VulkanMemoryAllocator-Hpp](https://github.com/YaaZ/VulkanMemoryAllocator-Hpp) would then introduce `VulkanMemoryAllocator::Hpp` and `VulkanMemoryAllocator::HppModule` targets to be consistent with the Vulkan targets.

It does not break anything and would only really be a cosmetic change, as another ALIAS target already exists (`GPUOpen::VulkanMemoryAllocator`). Having the same consistent target relationship between VMA and its Hpp bindings, similar to Vulkan and Vulkan-Hpp bindings, would be great!