### PR TITLE
Added missing pool locks in the VmaDefragmenterContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
   - Added function `vmaGetMemoryWin32Handle2` offering extra parameter `VkExternalMemoryHandleTypeFlagBits handleType`.
 - Added `VMA_VERSION` macro with library version number (#507).
 - Improvements in the algorithm choosing memory type when `VMA_MEMORY_USAGE_AUTO*` is used (#520).
-- Fixes for compatibility with C++20 modules on Clang 21 and GCC15 (#513, #514).
+- Fixed compatibility with C++20 modules on Clang 21 and GCC15 (#513, #514).
+- Fixed race condition in defragmentation (#529, #313).
 - Other fixes and improvements, including compatibility with various platforms and compilers, improvements in documentation, sample application, and tests.
 
 # 3.3.0 (2025-05-12)

--- a/include/vk_mem_alloc.h
+++ b/include/vk_mem_alloc.h
@@ -12221,6 +12221,8 @@ VmaDefragmentationContext_T::VmaDefragmentationContext_T(
         m_BlockVectorCount = 1;
         m_PoolBlockVector = &info.pool->m_BlockVector;
         m_pBlockVectors = &m_PoolBlockVector;
+
+        VmaMutexLockWrite lock(m_PoolBlockVector->m_Mutex, hAllocator->m_UseMutex);
         m_PoolBlockVector->SetIncrementalSort(false);
         m_PoolBlockVector->SortByFreeSize();
     }
@@ -12234,6 +12236,7 @@ VmaDefragmentationContext_T::VmaDefragmentationContext_T(
             VmaBlockVector* vector = m_pBlockVectors[i];
             if (vector != VMA_NULL)
             {
+                VmaMutexLockWrite lock(vector->m_Mutex, hAllocator->m_UseMutex);
                 vector->SetIncrementalSort(false);
                 vector->SortByFreeSize();
             }
@@ -12264,6 +12267,7 @@ VmaDefragmentationContext_T::~VmaDefragmentationContext_T()
 {
     if (m_PoolBlockVector != VMA_NULL)
     {
+        VmaMutexLockWrite lock(m_PoolBlockVector->m_Mutex, m_PoolBlockVector->m_hAllocator->m_UseMutex);
         m_PoolBlockVector->SetIncrementalSort(true);
     }
     else
@@ -12272,7 +12276,10 @@ VmaDefragmentationContext_T::~VmaDefragmentationContext_T()
         {
             VmaBlockVector* vector = m_pBlockVectors[i];
             if (vector != VMA_NULL)
+            {
+                VmaMutexLockWrite lock(vector->m_Mutex, vector->m_hAllocator->m_UseMutex);
                 vector->SetIncrementalSort(true);
+            }
         }
     }
 

--- a/include/vk_mem_alloc.h
+++ b/include/vk_mem_alloc.h
@@ -12377,7 +12377,11 @@ VkResult VmaDefragmentationContext_T::DefragmentPassEnd(VmaDefragmentationPassMo
         {
         case VMA_DEFRAGMENTATION_MOVE_OPERATION_COPY:
         {
-            uint8_t mapCount = move.srcAllocation->SwapBlockAllocation(vector->m_hAllocator, move.dstTmpAllocation);
+            uint8_t mapCount = 0;
+            {
+                VmaMutexLockWrite swapLock(vector->GetMutex(), vector->GetAllocator()->m_UseMutex);
+                mapCount = move.srcAllocation->SwapBlockAllocation(vector->m_hAllocator, move.dstTmpAllocation);
+            }
             if (mapCount > 0)
             {
                 allocator = vector->m_hAllocator;


### PR DESCRIPTION
We ran into the same issue that's also detailed in #313 and turol was nice enough to run this with TSAN so I figured I would be nice enough and add the missing locks.

There is a way to trigger this without running TSAN by using a debug sort function like MSVC provides:

```cpp
template<typename it, typename comp>
void debug_check_sort_fwd(it first, it last, comp c)
{
	assert(std::is_sorted(first, last, c));
}

template<typename RandomAccessIterator, typename Comp>
void debug_check_sort(RandomAccessIterator first_it, RandomAccessIterator last_it, Comp comp)
{
	using diff_t = typename iterator_traits<RandomAccessIterator>::difference_type;

	dev_assert(std::is_sorted(first_it, last_it, comp));
	// Limit the number of elements we need to check.
	diff_t size = last_it - first_it > diff_t(100) ? diff_t(100) : last_it - first_it;
	diff_t p    = 0;
	while (p < size) {
		diff_t q = p + diff_t(1);
		// Find first element that is greater than *(first_it+p).
		while (q < size && !comp(*(first_it + p), *(first_it + q))) {
			++q;
		}
		// Check that the elements from p to q are equal between each other.
		for (diff_t b = p; b < q; ++b) {
			for (diff_t a = p; a <= b; ++a) {
				assert(!comp(*(first_it + a), *(first_it + b)));
				assert(!comp(*(first_it + b), *(first_it + a)));
			}
		}
		// Check that elements between p and q are less than between q and size.
		for (diff_t a = p; a < q; ++a) {
			for (diff_t b = q; b < size; ++b) {
				assert(	comp(*(first_it + a), *(first_it + b)));
				assert(	!comp(*(first_it + b), *(first_it + a)));
			}
		}
		// Skip these equal elements.
		p = q;
	}
}

template<typename I>
void debug_sort(I first, I last)
{
	std::sort(first, last);
	debug_check_sort(first, last, std::less<decltype(*first)>());
}

template<typename I, typename C>
void debug_sort(I first, I last, C comp)
{
	std::sort(first, last, comp);
	debug_check_sort(first, last, comp);
}
```

If you slot this into `VMA_SORT()` you will occasionally hit the sort assertions depending on how the race goes.